### PR TITLE
Audioread Fallback for .m4a files

### DIFF
--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import numpy as np
 import soundfile
-import audioread
+import audioread as ar
 
 import paderbox.utils.process_caller as pc
 from paderbox.io.path_utils import normalize_path
@@ -168,7 +168,7 @@ def load_audio(
 
     try:
         if path[-3:] == 'm4a':
-            with audioread.audio_open(
+            with ar.audio_open(
                     path
             ) as f:
                 samplerate = f.samplerate

--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -167,7 +167,9 @@ def load_audio(
         raise ValueError(unit)
 
     try:
-        if path[-3:] == 'm4a':
+        if Path(path).suffix == '.m4a':
+            assert (start == 0 and stop is None), \
+                'audioread does not support partial loading of audio files'
             with ar.audio_open(
                     path
             ) as f:


### PR DESCRIPTION
Adds .m4a to supported filetypes of pb.audioread by exchanging SoundFile with audioread for .m4a files.