### PR TITLE
Fixing load_audio dtype BytesIO

### DIFF
--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -167,7 +167,7 @@ def load_audio(
         raise ValueError(unit)
 
     try:
-        if Path(path).suffix == '.m4a':
+        if isinstance(path, (str, Path)) and (Path(path).suffix == '.m4a'):
             assert (start == 0 and stop is None), \
                 'audioread does not support partial loading of audio files'
             with ar.audio_open(

--- a/tests/io_tests/test_dump_load_audio.py
+++ b/tests/io_tests/test_dump_load_audio.py
@@ -1,8 +1,10 @@
+import io
+
 import numpy as np
 import soundfile
 
 from paderbox.io import load_audio
-from paderbox.io.audiowrite import dump_audio
+from paderbox.io.audiowrite import dump_audio, dumps_audio
 from paderbox.testing.testfile_fetcher import get_file_path
     
 import pytest
@@ -86,6 +88,8 @@ class TestIOAudio:
         assert get_audio_type(path) == dumped_type
         b = load_audio(path, dtype=load_type)
         assert b.dtype == loaded_dtype
+        content = io.BytesIO(dumps_audio(a, dtype=dump_type, normalize=False))
+        c = load_audio(content, dtype=load_type)
 
     @pytest.mark.parametrize("file,fails",
     [


### PR DESCRIPTION
Fixes audioread for data of type BytesIO and adds test case for this error