### PR TITLE
py_query: support non identifier column names, add globals dict and add return_selection

### DIFF
--- a/paderbox/utils/pandas_utils.py
+++ b/paderbox/utils/pandas_utils.py
@@ -67,7 +67,8 @@ def py_query(
         setup_code: legacy argument, Superseded by the globals argument.
             Additional code which runs before the query conditions.
             You may use this for additional imports.
-        globals: Specify some global names. Useful for imports.
+        globals: Specify some global names. Useful for imports. See doctest how
+            to use it.
         return_selection: Whether to return the selection of the data or the
             selection indices.
 

--- a/paderbox/utils/pandas_utils.py
+++ b/paderbox/utils/pandas_utils.py
@@ -12,7 +12,7 @@ def py_query(
         allow_empty_result=False,
         setup_code='',
         globals=None,
-        return_selection=False,
+        return_selected_data=True,
 ):
     """
     Alternative: pd.DataFrame.query:
@@ -69,8 +69,8 @@ def py_query(
             You may use this for additional imports.
         globals: Specify some global names. Useful for imports. See doctest how
             to use it.
-        return_selection: Whether to return the selection of the data or the
-            selection indices.
+        return_selected_data: Whether to return the selection of the data or
+            the selection indices.
 
     Returns:
         data[selection] if not return_selection else selection
@@ -139,13 +139,11 @@ def func({', '.join(keywords)}):
         raise Exception(code) from e
 
     selection = data.apply(lambda row: func(row.name, **row), axis=1)
-    if return_selection:
-        return selection
+    assert allow_empty_result or len(selection) > 0, len(selection)
+    if return_selected_data:
+        return data[selection]
     else:
-        data = data[selection]
-
-        assert allow_empty_result or len(data) > 0, len(data)
-        return data
+        return selection
 
 
 def _unique_elements(pd_series):

--- a/paderbox/utils/pandas_utils.py
+++ b/paderbox/utils/pandas_utils.py
@@ -7,9 +7,12 @@ import pandas as pd
 def py_query(
         data: pd.DataFrame,
         query,
+        *,
         use_pd_query=False,
         allow_empty_result=False,
         setup_code='',
+        globals=None,
+        return_selection=False,
 ):
     """
     Alternative: pd.DataFrame.query:
@@ -39,17 +42,37 @@ def py_query(
        a  b
     1  3  4
 
+    To access column names that aren't valid python identifiers (e.g. the name
+    contains a whitespace), you have to use the kwargs dictionary:
+    >>> df = pd.DataFrame([{'a b': 1, 'b': 2}, {'a b': 3, 'b': 4}])
+    >>> py_query(df, 'kwargs["a b"] == 1')
+       a b  b
+    0    1  2
+
+    When you need a package function, you have to specify it in the globals
+    dict. e.g.:
+    >>> import numpy as np
+    >>> df = pd.DataFrame([{'a': 1, 'b': 2}, {'a': 3, 'b': 4}])
+    >>> py_query(df, 'np.equal(a, 1)', globals={'np': np})
+       a  b
+    0  1  2
+
     Args:
-        data:
+        data: pandas.DataFrame
         query: str or list of str. If list of str the strings get join by a
-            logical and to be a str. For examples see doctest.
+            logical `and` to be a str. For examples see doctest.
              Note: Use index to get access to the index.
         use_pd_query:  Pandas query is much faster but limited
         allow_empty_result:
-        setup_code: Additional code which runs before the query conditions.
+        setup_code: legacy argument, Superseded by the globals argument.
+            Additional code which runs before the query conditions.
             You may use this for additional imports.
+        globals: Specify some global names. Useful for imports.
+        return_selection: Whether to return the selection of the data or the
+            selection indices.
 
     Returns:
+        data[selection] if not return_selection else selection
 
     """
     if query is False:
@@ -77,23 +100,51 @@ def py_query(
     else:
         assert use_pd_query is False, use_pd_query
 
+    keywords = ['index'] + list(data)
+
+    def is_valid_variable_name(name):
+        import ast
+        # https://stackoverflow.com/a/36331242/5766934
+        try:
+            ast.parse('{} = None'.format(name))
+            return True
+        except (SyntaxError, ValueError, TypeError):
+            return False
+
+    keywords = [
+        k
+        for k in keywords
+        if is_valid_variable_name(k)
+    ] + ['**kwargs']
+
     d = {}
     code = f"""
-def func({', '.join(['index'] + list(data))}):
+def func({', '.join(keywords)}):
     {setup_code}
-    return {query}
-"""
     try:
-        exec(code, {}, d)
+        return {query}
+    except Exception:
+        raise Exception('See above error message. Locals are:', locals())
+"""
+
+    if globals is None:
+        globals = {}
+    else:
+        globals = globals.copy()
+    try:
+        exec(code, globals, d)
         func = d['func']
     except Exception as e:
         raise Exception(code) from e
 
     selection = data.apply(lambda row: func(row.name, **row), axis=1)
-    data = data[selection]
+    if return_selection:
+        return selection
+    else:
+        data = data[selection]
 
-    assert allow_empty_result or len(data) > 0, len(data)
-    return data
+        assert allow_empty_result or len(data) > 0, len(data)
+        return data
 
 
 def _unique_elements(pd_series):


### PR DESCRIPTION
Add support for non identifier column names:
 - Old: When a column had a non identifier column name (e.g. whitespace in the name) py_query failed
 - New: The column entry can be accessed with the `kwargs` dict (see doctest)

Add globals dict:
 - The globals dict for the query was not accessible. Now the user can influence the globals dict and `setup_code` is no longer nessesary.
 - example for using a numpy function in the query: `py_query(..., globals={'np': np})` 

Add option return_selection:
 - Allow to return the selection indices instead of `data[return_selection]`