### PR TITLE
Fix ArrayInterval.sum if emtpy or inverse_mode=True

### DIFF
--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -508,9 +508,10 @@ class ArrayInterval:
         >>> a = ArrayInterval([True, False, False, True])
         >>> np.sum(a)
         2
-        >>> a = zeros(10)
-        >>> np.sum(a)
+        >>> np.sum(zeros(10))
         0
+        >>> np.sum(ones(10))
+        10
         """
         assert out is None, (out, axis, self)
         assert axis is None, (axis, out, self)

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -508,11 +508,20 @@ class ArrayInterval:
         >>> a = ArrayInterval([True, False, False, True])
         >>> np.sum(a)
         2
+        >>> a = zeros(10)
+        >>> np.sum(a)
+        0
         """
         assert out is None, (out, axis, self)
         assert axis is None, (axis, out, self)
-        a, b = np.sum(self.normalized_intervals, axis=0)
-        return b - a
+        if not self.normalized_intervals:
+            sum = 0
+        else:
+            a, b = np.sum(self.normalized_intervals, axis=0)
+            sum = b - a
+        if self.inverse_mode:
+            sum = self.shape[0] - sum
+        return sum
 
     def __or__(self, other):
         """


### PR DESCRIPTION
Previously, `ArrayInterval.sum` was broken for emtpy intervals (`len(interval.intervals) == 0`) and when `interval.inverse_mode = True`. I'm not a 100% sure if `self.shape[0]` is correct.