### PR TITLE
Allow export of ArrayIntervals as tuple

### DIFF
--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -371,6 +371,7 @@ class ArrayInterval:
         >>> ai.as_tuple
         ('1:4, 5:20, 21:25', (50,))
         """
+        assert self.inverse_mode is False, 'Export of intervals as tuple is only valid for normal mode, not inverse mode!' 
         return self._intervals_as_str, self.shape
 
     @staticmethod

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -362,8 +362,9 @@ class ArrayInterval:
     def as_serializable(self):
         """
         Exports intervals and length of `ArrayInterval` to a serializable object.
-        Intervals are exported as self._intervals_to_str to be human readable. 
-        Allows easy export of ArrayIntervals, e.g. into .json format. 
+        Intervals are exported as `self._intervals_to_str` to be human readable. 
+        Allows easy export of `ArrayIntervals`, e.g. into .json format. 
+        
         >>> from IPython.lib.pretty import pprint
         >>> from paderbox.array.interval.core import ArrayInterval
         >>> ai = ArrayInterval.from_str('1:4, 5:20, 21:25', shape=50)
@@ -383,6 +384,7 @@ class ArrayInterval:
             array: Object of length 2 with items (str: intervals, shape)
         Returns:
             `ArrayInterval` with specified intervals and shape
+            
         >>> from IPython.lib.pretty import pprint
         >>> from paderbox.array.interval.core import ArrayInterval
         >>> at = ('1:4, 5:20, 21:25', 50)

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -358,7 +358,6 @@ class ArrayInterval:
         i_str = ', '.join(i_str)
         return i_str
 
-    @property
     def to_serializable(self):
         """
         Exports intervals and length of `ArrayInterval` to a serializable object.

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -359,7 +359,7 @@ class ArrayInterval:
         return i_str
 
     @property
-    def as_serializable(self):
+    def to_serializable(self):
         """
         Exports intervals and length of `ArrayInterval` to a serializable object.
         Intervals are exported as `self._intervals_to_str` to be human readable. 
@@ -370,7 +370,7 @@ class ArrayInterval:
         >>> ai = ArrayInterval.from_str('1:4, 5:20, 21:25', shape=50)
         >>> ai
         ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
-        >>> ai.as_serializable
+        >>> ai.to_serializable
         ('1:4, 5:20, 21:25', (50,))
         """
         assert self.inverse_mode is False, 'Export of intervals as tuple is only valid for normal mode, not inverse mode!' 
@@ -379,12 +379,14 @@ class ArrayInterval:
     @staticmethod
     def from_serializable(obj):
         """
-        Reverts `as_serializable`.
+        Reverts `to_serializable`.
         Args:
-            array: Object of length 2 with items (str: intervals, shape)
+            obj: Object of length 2 with items (str: intervals, shape)
+            
         Returns:
             `ArrayInterval` with specified intervals and shape
             
+        Example:
         >>> from IPython.lib.pretty import pprint
         >>> from paderbox.array.interval.core import ArrayInterval
         >>> at = ('1:4, 5:20, 21:25', 50)

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -392,7 +392,7 @@ class ArrayInterval:
         ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
         """
         assert len(obj) == 2, f'Expects object of length 2 with items (intervals, shape), got: {obj}' 
-        return ArrayInterval_from_str(array[0], shape=array[1])
+        return ArrayInterval_from_str(obj[0], shape=obj[1])
 
     def __repr__(self):
         if self.inverse_mode:

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -359,33 +359,39 @@ class ArrayInterval:
         return i_str
 
     @property
-    def as_tuple(self):
+    def as_serializable(self):
         """
-        Exports intervals and length of ArrayInterval to a tuple. 
+        Exports intervals and length of ArrayInterval to a serializable object.
+        Reverting 
         Allows easy export of ArrayIntervals, e.g. into .json format. 
         >>> from IPython.lib.pretty import pprint
         >>> from paderbox.array.interval.core import ArrayInterval
         >>> ai = ArrayInterval.from_str('1:4, 5:20, 21:25', shape=50)
         >>> ai
         ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
-        >>> ai.as_tuple
+        >>> ai.as_serializable
         ('1:4, 5:20, 21:25', (50,))
         """
         assert self.inverse_mode is False, 'Export of intervals as tuple is only valid for normal mode, not inverse mode!' 
         return self._intervals_as_str, self.shape
 
     @staticmethod
-    def from_tuple(array):
+    def from_serialized(array):
         """
+        Reverts serialization from 'as_serializable.
+        Args:
+            array: Object of length 2 with items (str: intervals, shape)
+        Returns:
+            `ArrayInterval` with specified intervals and shape
         >>> from IPython.lib.pretty import pprint
         >>> from paderbox.array.interval.core import ArrayInterval
         >>> at = ('1:4, 5:20, 21:25', 50)
         >>> at
         ('1:4, 5:20, 21:25', 50)
-        >>> ArrayInterval.from_tuple(at)
+        >>> ArrayInterval.from_serialized(at)
         ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
         """
-        assert len(array) == 2, f'Expects tuple with items (intervals, shape), got: {array}' 
+        assert len(array) == 2, f'Expects object of length 2 with items (intervals, shape), got: {array}' 
         return ArrayInterval_from_str(array[0], shape=array[1])
 
     def __repr__(self):

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -89,7 +89,7 @@ def zeros(shape: Optional[Union[int, tuple, list]] = None) -> 'ArrayInterval':
     """
     ai = ArrayInterval.__new__(ArrayInterval)
 
-    if isinstance(shape, int):
+    if isinstance(shape, (int, np.int)):
         shape = [shape]
 
     if shape is not None:
@@ -357,6 +357,14 @@ class ArrayInterval:
 
         i_str = ', '.join(i_str)
         return i_str
+
+    @property
+    def as_tuple(self):
+        return self._intervals_as_str, self.shape
+
+    @staticmethod
+    def from_tuple(array):
+        return ArrayInterval_from_str(array[0], shape=array[1])
 
     def __repr__(self):
         if self.inverse_mode:

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -376,7 +376,7 @@ class ArrayInterval:
         return self._intervals_as_str, self.shape
 
     @staticmethod
-    def from_serialized(array):
+    def from_serializable(array):
         """
         Reverts serialization from 'as_serializable.
         Args:
@@ -388,7 +388,7 @@ class ArrayInterval:
         >>> at = ('1:4, 5:20, 21:25', 50)
         >>> at
         ('1:4, 5:20, 21:25', 50)
-        >>> ArrayInterval.from_serialized(at)
+        >>> ArrayInterval.from_serializable(at)
         ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
         """
         assert len(array) == 2, f'Expects object of length 2 with items (intervals, shape), got: {array}' 

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -384,7 +384,7 @@ class ArrayInterval:
         >>> ArrayInterval.from_tuple(at)
         ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
         """
-        assser len(array) == 2, f'Expects tuple with items (intervals, shape), got: {array}' 
+        assert len(array) == 2, f'Expects tuple with items (intervals, shape), got: {array}' 
         return ArrayInterval_from_str(array[0], shape=array[1])
 
     def __repr__(self):

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -89,7 +89,7 @@ def zeros(shape: Optional[Union[int, tuple, list]] = None) -> 'ArrayInterval':
     """
     ai = ArrayInterval.__new__(ArrayInterval)
 
-    if isinstance(shape, (int, np.int)):
+    if isinstance(shape, int):
         shape = [shape]
 
     if shape is not None:

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -361,8 +361,8 @@ class ArrayInterval:
     @property
     def as_serializable(self):
         """
-        Exports intervals and length of ArrayInterval to a serializable object.
-        Reverting 
+        Exports intervals and length of `ArrayInterval` to a serializable object.
+        Intervals are exported as self._intervals_to_str to be human readable. 
         Allows easy export of ArrayIntervals, e.g. into .json format. 
         >>> from IPython.lib.pretty import pprint
         >>> from paderbox.array.interval.core import ArrayInterval
@@ -376,9 +376,9 @@ class ArrayInterval:
         return self._intervals_as_str, self.shape
 
     @staticmethod
-    def from_serializable(array):
+    def from_serializable(obj):
         """
-        Reverts serialization from 'as_serializable.
+        Reverts `as_serializable`.
         Args:
             array: Object of length 2 with items (str: intervals, shape)
         Returns:
@@ -391,7 +391,7 @@ class ArrayInterval:
         >>> ArrayInterval.from_serializable(at)
         ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
         """
-        assert len(array) == 2, f'Expects object of length 2 with items (intervals, shape), got: {array}' 
+        assert len(obj) == 2, f'Expects object of length 2 with items (intervals, shape), got: {obj}' 
         return ArrayInterval_from_str(array[0], shape=array[1])
 
     def __repr__(self):

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -360,10 +360,28 @@ class ArrayInterval:
 
     @property
     def as_tuple(self):
+        """
+        >>> from IPython.lib.pretty import pprint
+        >>> from paderbox.array.interval.core import ArrayInterval
+        >>> ai = ArrayInterval.from_str('1:4, 5:20, 21:25', shape=50)
+        >>> ai
+        ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
+        >>> ai.as_tuple
+        ('1:4, 5:20, 21:25', (50,))
+        """
         return self._intervals_as_str, self.shape
 
     @staticmethod
     def from_tuple(array):
+        """
+        >>> from IPython.lib.pretty import pprint
+        >>> from paderbox.array.interval.core import ArrayInterval
+        >>> at = ('1:4, 5:20, 21:25', 50)
+        >>> at
+        ('1:4, 5:20, 21:25', 50)
+        >>> ArrayInterval.from_tuple(at)
+        ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
+        """
         return ArrayInterval_from_str(array[0], shape=array[1])
 
     def __repr__(self):

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -361,6 +361,8 @@ class ArrayInterval:
     @property
     def as_tuple(self):
         """
+        Exports intervals and length of ArrayInterval to a tuple. 
+        Allows easy export of ArrayIntervals, e.g. into .json format. 
         >>> from IPython.lib.pretty import pprint
         >>> from paderbox.array.interval.core import ArrayInterval
         >>> ai = ArrayInterval.from_str('1:4, 5:20, 21:25', shape=50)
@@ -382,6 +384,7 @@ class ArrayInterval:
         >>> ArrayInterval.from_tuple(at)
         ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
         """
+        assser len(array) == 2, f'Expects tuple with items (intervals, shape), got: {array}' 
         return ArrayInterval_from_str(array[0], shape=array[1])
 
     def __repr__(self):

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -369,7 +369,7 @@ class ArrayInterval:
         >>> ai = ArrayInterval.from_str('1:4, 5:20, 21:25', shape=50)
         >>> ai
         ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
-        >>> ai.to_serializable
+        >>> ai.to_serializable()
         ('1:4, 5:20, 21:25', (50,))
         """
         assert self.inverse_mode is False, 'Export of intervals as tuple is only valid for normal mode, not inverse mode!' 


### PR DESCRIPTION
Enables easily saving ArrayIntervals to and loading them from .json files