### PR TITLE
Fix ArrayInterval.__reduce__ for inverse mode

### DIFF
--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -30,7 +30,6 @@ def ArrayInterval_from_str(string, shape):
     """
     ai = zeros(shape)
     if string == '':
-        print('empty interval found')
         pass
     else:
         if not ',' in string:
@@ -274,6 +273,12 @@ class ArrayInterval:
         else:
             return self[:]
 
+    @staticmethod
+    def _reduce_restore(intervals_as_str, shape, inverse_mode):
+        interval = ArrayInterval.from_str(intervals_as_str, shape)
+        interval.inverse_mode = inverse_mode
+        return interval
+
     def __reduce__(self):
         """
         >>> from IPython.lib.pretty import pprint
@@ -288,10 +293,23 @@ class ArrayInterval:
         >>> jsonpickle.loads(jsonpickle.dumps(ai))
         ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
         >>> pprint(json.loads(jsonpickle.dumps(ai)))
-        {'py/reduce': [{'py/function': 'paderbox.array.interval.core.ArrayInterval_from_str'},
-          {'py/tuple': ['1:4, 5:20, 21:25', 50]}]}
+        {'py/reduce': [{'py/function': 'paderbox.array.interval.core.ArrayInterval._reduce_restore'},
+          {'py/tuple': ['1:4, 5:20, 21:25', 50, False]}]}
+        >>> ai = ArrayInterval.from_str('1:4, 5:20, 21:25', shape=50)
+        >>> ai.inverse_mode = True
+        >>> ai
+        ArrayInterval("1:4, 5:20, 21:25", shape=(50,), inverse_mode=True)
+        >>> pickle.loads(pickle.dumps(ai))
+        ArrayInterval("1:4, 5:20, 21:25", shape=(50,), inverse_mode=True)
+        >>> jsonpickle.loads(jsonpickle.dumps(ai))
+        ArrayInterval("1:4, 5:20, 21:25", shape=(50,), inverse_mode=True)
+        >>> pprint(json.loads(jsonpickle.dumps(ai)))
+        {'py/reduce': [{'py/function': 'paderbox.array.interval.core.ArrayInterval._reduce_restore'},
+          {'py/tuple': ['1:4, 5:20, 21:25', 50, True]}]}
         """
-        return self.from_str, (self._intervals_as_str, self.shape[-1])
+        return self._reduce_restore, (
+            self._intervals_as_str, self.shape[-1], self.inverse_mode
+        )
 
     _intervals_normalized = True
     # _normalized_intervals = ()

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -16,7 +16,7 @@ from paderbox.array.interval.util import (
 )
 
 
-def ArrayInterval_from_str(string, shape):
+def ArrayInterval_from_str(string, shape, inverse_mode=False):
     """
     >>> ArrayInterval_from_str('1:4, 5:20, 21:25', shape=50)
     ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
@@ -38,6 +38,7 @@ def ArrayInterval_from_str(string, shape):
             ai.add_intervals_from_str(string)
         except Exception as e:
             raise Exception(string) from e
+    ai.inverse_mode = inverse_mode
     return ai
 
 
@@ -273,12 +274,6 @@ class ArrayInterval:
         else:
             return self[:]
 
-    @staticmethod
-    def _reduce_restore(intervals_as_str, shape, inverse_mode):
-        interval = ArrayInterval.from_str(intervals_as_str, shape)
-        interval.inverse_mode = inverse_mode
-        return interval
-
     def __reduce__(self):
         """
         >>> from IPython.lib.pretty import pprint
@@ -293,7 +288,7 @@ class ArrayInterval:
         >>> jsonpickle.loads(jsonpickle.dumps(ai))
         ArrayInterval("1:4, 5:20, 21:25", shape=(50,))
         >>> pprint(json.loads(jsonpickle.dumps(ai)))
-        {'py/reduce': [{'py/function': 'paderbox.array.interval.core.ArrayInterval._reduce_restore'},
+        {'py/reduce': [{'py/function': 'paderbox.array.interval.core.ArrayInterval_from_str'},
           {'py/tuple': ['1:4, 5:20, 21:25', 50, False]}]}
         >>> ai = ArrayInterval.from_str('1:4, 5:20, 21:25', shape=50)
         >>> ai.inverse_mode = True
@@ -304,10 +299,10 @@ class ArrayInterval:
         >>> jsonpickle.loads(jsonpickle.dumps(ai))
         ArrayInterval("1:4, 5:20, 21:25", shape=(50,), inverse_mode=True)
         >>> pprint(json.loads(jsonpickle.dumps(ai)))
-        {'py/reduce': [{'py/function': 'paderbox.array.interval.core.ArrayInterval._reduce_restore'},
+        {'py/reduce': [{'py/function': 'paderbox.array.interval.core.ArrayInterval_from_str'},
           {'py/tuple': ['1:4, 5:20, 21:25', 50, True]}]}
         """
-        return self._reduce_restore, (
+        return self.from_str, (
             self._intervals_as_str, self.shape[-1], self.inverse_mode
         )
 


### PR DESCRIPTION
Previously, `ArrayInterval.__reduce__` ignored `inverse_mode`.