### PR TITLE
Normalize and validate shape of ArrayInterval while setting it

### DIFF
--- a/paderbox/array/__init__.py
+++ b/paderbox/array/__init__.py
@@ -2,3 +2,4 @@ from .context import *
 from .padding import *
 from .rearrange import *
 from .segment import *
+from . import interval

--- a/paderbox/array/interval/__init__.py
+++ b/paderbox/array/interval/__init__.py
@@ -13,6 +13,7 @@ of a long audio file (> 2h) in memory.
 """
 from .core import zeros, ones
 from .core import ArrayInterval
+from .core import ArrayInterval_from_str as from_str
 
 from .rttm import from_rttm
 from .rttm import from_rttm_str

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -46,9 +46,13 @@ def intervals_to_str(intervals):
     return ', '.join(f'{start}:{end}' for start, end in intervals)
 
 
-def _validate_shape(shape):
-    if shape is None or isinstance(shape, int):
-        return
+def _normalize_shape(shape):
+    if shape is None:
+        return None
+
+    if isinstance(shape, int):
+        return shape,
+
     if not isinstance(shape, (tuple, list)):
         raise TypeError(f'Invalid shape {shape} of type {type(shape)}')
     if not len(shape) == 1:
@@ -58,12 +62,6 @@ def _validate_shape(shape):
             f'Invalid shape {shape} with elements of type {type(shape[0])}'
         )
 
-
-def _normalize_shape(shape):
-    if shape is None:
-        return None
-    if isinstance(shape, int):
-        return shape,
     return tuple(shape)
 
 
@@ -252,7 +250,6 @@ class ArrayInterval:
 
     @shape.setter
     def shape(self, shape):
-        _validate_shape(shape)
         self._shape = _normalize_shape(shape)
 
     def __copy__(self):

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -46,6 +46,27 @@ def intervals_to_str(intervals):
     return ', '.join(f'{start}:{end}' for start, end in intervals)
 
 
+def _validate_shape(shape):
+    if shape is None or isinstance(shape, int):
+        return
+    if not isinstance(shape, (tuple, list)):
+        raise TypeError(f'Invalid shape {shape} of type {type(shape)}')
+    if not len(shape) == 1:
+        raise ValueError(f'Invalid shape {shape} has to have length 1')
+    if not isinstance(shape[0], int):
+        raise TypeError(
+            f'Invalid shape {shape} with elements of type {type(shape[0])}'
+        )
+
+
+def _normalize_shape(shape):
+    if shape is None:
+        return None
+    if isinstance(shape, int):
+        return shape,
+    return tuple(shape)
+
+
 def zeros(shape: Optional[Union[int, tuple, list]] = None) -> 'ArrayInterval':
     """
     Instantiate an `ArrayInterval` filled with zeros.
@@ -93,14 +114,6 @@ def zeros(shape: Optional[Union[int, tuple, list]] = None) -> 'ArrayInterval':
 
     """
     ai = ArrayInterval.__new__(ArrayInterval)
-
-    if isinstance(shape, int):
-        shape = [shape]
-
-    if shape is not None:
-        assert len(shape) == 1, shape
-        shape = tuple(shape)
-
     ai.shape = shape
     return ai
 
@@ -152,14 +165,6 @@ def ones(shape: Optional[Union[int, tuple, list]] = None) -> 'ArrayInterval':
     """
     ai = ArrayInterval.__new__(ArrayInterval)
     ai.inverse_mode = True
-
-    if isinstance(shape, int):
-        shape = [shape]
-
-    if shape is not None:
-        assert len(shape) == 1, shape
-        shape = tuple(shape)
-
     ai.shape = shape
     return ai
 
@@ -201,7 +206,7 @@ class ArrayInterval:
 
         """
         if isinstance(array, ArrayInterval):
-            self.shape = array.shape
+            self._shape = array.shape
             self.inverse_mode = array.inverse_mode
             self.intervals = array.intervals
         else:
@@ -232,7 +237,7 @@ class ArrayInterval:
 
             # ai = ArrayInterval(shape=array.shape)
             self.inverse_mode = inverse_mode
-            self.shape = array.shape
+            self._shape = array.shape
 
             if inverse_mode:
                 for start, stop in zip(rising, falling):
@@ -240,6 +245,15 @@ class ArrayInterval:
             else:
                 for start, stop in zip(rising, falling):
                     self[start:stop] = 1
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        _validate_shape(shape)
+        self._shape = _normalize_shape(shape)
 
     def __copy__(self):
         if self.inverse_mode:

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -55,9 +55,14 @@ def _normalize_shape(shape):
 
     if not isinstance(shape, (tuple, list)):
         raise TypeError(f'Invalid shape {shape} of type {type(shape)}')
+
+    # As of now, we only support 1D. We haven't decided yet how to handle
+    # higher numbers of dimensions as it is unclear what they mean. Probably
+    # the last dimension will remain as it is and the earlier dimensions will
+    # be independent dimensions.
     if not len(shape) == 1:
         raise ValueError(f'Invalid shape {shape} has to have length 1')
-    if not isinstance(shape[0], int):
+    if not isinstance(shape[-1], int):
         raise TypeError(
             f'Invalid shape {shape} with elements of type {type(shape[0])}'
         )

--- a/tests/array_tests/test_array_interval.py
+++ b/tests/array_tests/test_array_interval.py
@@ -1,4 +1,5 @@
 import pytest
+from paderbox.array import interval
 
 from paderbox.array.interval.util import (
     cy_non_intersection,
@@ -28,3 +29,23 @@ def test_cy_intersection():
     assert cy_intersection((1, 4), ((0, 2), (3, 5))) == ((1, 2), (3, 4))
     assert cy_intersection((1, 2), ((0, 3),)) == ((1, 2),)
     assert cy_intersection((4, 5), ((0, 3),)) == ()
+
+
+def test_shape():
+    ai = interval.zeros(1)
+    assert isinstance(ai.shape, tuple)
+    assert isinstance(ai.shape[0], int)
+    interval.zeros((1,))
+    assert isinstance(ai.shape, tuple)
+    assert isinstance(ai.shape[0], int)
+    interval.zeros([1, ])
+    assert isinstance(ai.shape, tuple)
+    assert isinstance(ai.shape[0], int)
+    with pytest.raises(TypeError):
+        interval.zeros('a')
+    with pytest.raises(TypeError):
+        interval.zeros({'num_samples': 42})
+    with pytest.raises(TypeError):
+        interval.zeros(('asdf', ))
+    with pytest.raises(ValueError):
+        interval.zeros((1, 2))


### PR DESCRIPTION
Before, it was possible to do
```python
ai = zeros('a')
```
without an exception. Now it raises an exception and also checks the shape on assignment like `ai.shape = (1, 2, 3, 4)`.