### PR TITLE
Windows tests

### DIFF
--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -5,7 +5,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -1,0 +1,41 @@
+name: Tests Windows
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: [3.8]  # Test only one Python Version for Windows
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install numpy scipy Cython
+        pip install flake8 pytest pytest-cov codecov
+        pip install --editable .[all]
+        pip install git+https://github.com/fgnt/pb_bss.git#egg=pb_bss[all]
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax error or undefined names
+        #flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: pytest -v "tests/" "paderbox/"
+
+    - name: coverage
+      run: python -m coverage xml --include="paderbox*"

--- a/paderbox/array/interval/core.py
+++ b/paderbox/array/interval/core.py
@@ -193,18 +193,18 @@ class ArrayInterval:
                 fine.
 
         Examples:
-            >>> ai = ArrayInterval(np.array([1, 1, 0, 1, 0, 0, 1, 1, 0], dtype=np.bool))
+            >>> ai = ArrayInterval(np.array([1, 1, 0, 1, 0, 0, 1, 1, 0], dtype=bool))
             >>> ai
             ArrayInterval("0:2, 3:4, 6:8", shape=(9,))
             >>> ai[:]
             array([ True,  True, False,  True, False, False,  True,  True, False])
-            >>> a = np.array([1, 1, 1, 1], dtype=np.bool)
+            >>> a = np.array([1, 1, 1, 1], dtype=bool)
             >>> assert all(a == ArrayInterval(a)[:])
-            >>> a = np.array([0, 0, 0, 0], dtype=np.bool)
+            >>> a = np.array([0, 0, 0, 0], dtype=bool)
             >>> assert all(a == ArrayInterval(a)[:])
-            >>> a = np.array([0, 1, 1, 0], dtype=np.bool)
+            >>> a = np.array([0, 1, 1, 0], dtype=bool)
             >>> assert all(a == ArrayInterval(a)[:])
-            >>> a = np.array([1, 0, 0, 1], dtype=np.bool)
+            >>> a = np.array([1, 0, 0, 1], dtype=bool)
             >>> assert all(a == ArrayInterval(a)[:])
 
         """
@@ -219,7 +219,7 @@ class ArrayInterval:
                     f'Only 1-dimensional arrays can be converted to '
                     f'ArrayInterval, not {array!r} with ndim={array.ndim}'
                 )
-            if array.dtype != np.bool:
+            if array.dtype != bool:
                 raise ValueError(
                     f'Only boolean array can be converted to ArrayInterval, not'
                     f'{array!r} with dtype={array.dtype}'
@@ -265,7 +265,7 @@ class ArrayInterval:
         ai.intervals = self.intervals
         return ai
 
-    def __array__(self, dtype=np.bool):
+    def __array__(self, dtype=bool):
         """
         Special numpy method. This method is used by numpy to cast foreign
         types to numpy.
@@ -282,7 +282,7 @@ class ArrayInterval:
             RuntimeError: You cannot cast an ArrayInterval to numpy
             when the shape is unknown.
         """
-        assert dtype == np.bool, dtype
+        assert dtype == bool, dtype
         if self.shape is None:
             raise RuntimeError(
                 f'You cannot cast an {self.__class__.__name__} to numpy\n'
@@ -643,17 +643,17 @@ class ArrayInterval:
 
         # This is numpy behavior
         if stop <= start:
-            return np.zeros(0, dtype=np.bool)
+            return np.zeros(0, dtype=bool)
 
         intervals = cy_intersection((start, stop), self.normalized_intervals)
 
         if self.inverse_mode:
-            arr = np.ones(stop - start, dtype=np.bool)
+            arr = np.ones(stop - start, dtype=bool)
 
             for i_start, i_end in intervals:
                 arr[i_start - start:i_end - start] = False
         else:
-            arr = np.zeros(stop - start, dtype=np.bool)
+            arr = np.zeros(stop - start, dtype=bool)
 
             for i_start, i_end in intervals:
                 arr[i_start - start:i_end - start] = True

--- a/paderbox/array/interval/rttm.py
+++ b/paderbox/array/interval/rttm.py
@@ -138,7 +138,7 @@ def to_rttm_str(data, sample_rate=16000):
     >>> ar1 = zeros(None)
     >>> ar1[0:16000] = 1
     >>> ar1[32000:48000] = 1
-    >>> ar2 = np.zeros(shape=50000, dtype=np.bool)
+    >>> ar2 = np.zeros(shape=50000, dtype=bool)
     >>> ar2[0:32000] = 1
     >>> data = {'S02': {'1': ar1, '2': ar2}}
     >>> data

--- a/paderbox/array/padding.py
+++ b/paderbox/array/padding.py
@@ -81,7 +81,7 @@ def pad_axis(array, pad_width, *, axis, mode='constant', **pad_kwargs):
     """
     array = np.asarray(array)
 
-    npad = np.zeros([array.ndim, 2], dtype=np.int)
+    npad = np.zeros([array.ndim, 2], dtype=int)
     npad[axis, :] = pad_width
     return np.pad(array, pad_width=npad, mode=mode, **pad_kwargs)
 

--- a/paderbox/array/segment.py
+++ b/paderbox/array/segment.py
@@ -206,17 +206,17 @@ def segment_axis(x, length: int, shift: int, axis: int=-1,
     # Pad
     if end == 'pad':
         if x.shape[axis] < length:
-            npad = np.zeros([ndim, 2], dtype=np.int)
+            npad = np.zeros([ndim, 2], dtype=int)
             npad[axis, 1] = length - x.shape[axis]
             x = pad(x, pad_width=npad, mode=pad_mode, **pad_kwargs)
         elif shift != 1 and (x.shape[axis] + shift - length) % shift != 0:
-            npad = np.zeros([ndim, 2], dtype=np.int)
+            npad = np.zeros([ndim, 2], dtype=int)
             npad[axis, 1] = shift - ((x.shape[axis] + shift - length) % shift)
             x = pad(x, pad_width=npad, mode=pad_mode, **pad_kwargs)
 
     elif end == 'conv_pad':
         assert shift == 1, shift
-        npad = np.zeros([ndim, 2], dtype=np.int)
+        npad = np.zeros([ndim, 2], dtype=int)
         npad[axis, :] = length - shift
         x = pad(x, pad_width=npad, mode=pad_mode, **pad_kwargs)
     elif end is None:

--- a/paderbox/array/sparse.py
+++ b/paderbox/array/sparse.py
@@ -865,7 +865,7 @@ class SparseArray:
         >>> np.arange(10) * a
         array([ 0,  1,  2,  3,  4, 10, 12, 14, 16, 18])
         """
-        if isinstance(other, (np.float, np.int, np.complex)):
+        if isinstance(other, (float, int, complex)):
             # Scalar value, multiply everything by it
             arr = self.__class__(
                 shape=self.shape,
@@ -881,7 +881,7 @@ class SparseArray:
             return NotImplemented
 
     def __rmul__(self, other):
-        if isinstance(other, (np.float, np.int, np.complex)):
+        if isinstance(other, (float, int, complex)):
             # We can safely change the order for scalar multiplication
             return self * other
         else:

--- a/paderbox/array/sparse.py
+++ b/paderbox/array/sparse.py
@@ -115,7 +115,7 @@ def _get_pad_value(dtype, pad_value, device=None):
 
 
 def _pad_value_like(array, pad_value):
-    """Consructs a pad value with the same dtype and device as `array`."""
+    """Constructs a pad value with the same dtype and device as `array`."""
     if isinstance(array, torch.Tensor):
         device = array.device
     else:
@@ -141,8 +141,11 @@ def zeros(shape, dtype=np.float32):
     SparseArray(shape=(10,))
     >>> zeros(10).as_contiguous()
     array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0.], dtype=float32)
-    >>> zeros(10, dtype=np.int32).as_contiguous()
-    array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=int32)
+    >>> import os
+    >>> arr = zeros(10, dtype=np.int32).as_contiguous()  # int32 is the default integer type on Windows and will not be displayed automatically
+    >>> str(arr)
+    '[0 0 0 0 0 0 0 0 0 0]'
+    >>> assert arr.dtype == np.dtype('int64') or os.name == "nt" and arr.dtype == np.dtype('int32')
     >>> zeros(10, dtype=torch.float32).as_contiguous()
     tensor([0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])
     >>> zeros(10, dtype=torch.float32).device
@@ -211,22 +214,22 @@ class SparseArray:
 
 
     dtype is inferred from segments:
-    >>> a.dtype
-    dtype('int64')
-    >>> a.pad_value, type(a.pad_value)
-    (0, <class 'numpy.int64'>)
+    >>> import os
+    >>> assert a.dtype == np.dtype('int64') or os.name == "nt" and a.dtype == np.dtype('int32')
+    >>> a.pad_value
+    0
+    >>> assert str(type(a.pad_value)) == "<class 'numpy.int64'>" or os.name == "nt" and str(type(a.pad_value)) == "<class 'numpy.int32'>"
 
     Can't add segments with differing dtypes
     >>> a[:3] = np.ones(3, dtype=np.float32)
     Traceback (most recent call last):
       ...
-    TypeError: Type mismatch: SparseArray has dtype int64, but assigned array has dtype float32
+    TypeError: Type mismatch: SparseArray has dtype ..., but assigned array has dtype float32
 
     Adding multiple SparseArray returns a SparseArray
     >>> b = SparseArray(a.shape)
     >>> b[10:15] = 8
-    >>> b.dtype
-    dtype('int64')
+    >>> assert b.dtype == np.dtype('int64') or os.name == "nt" and b.dtype == np.dtype('int32')
     >>> a + b
     SparseArray(_SparseSegment(onset=5, array=array([1, 1, 1, 1, 1])), _SparseSegment(onset=10, array=array([8, 8, 8, 8, 8])), _SparseSegment(onset=15, array=array([2, 2, 2, 2, 2])), shape=(20,))
     >>> np.asarray(a + b)
@@ -288,8 +291,8 @@ class SparseArray:
         dtype('float32')
         >>> a = SparseArray(10)
         >>> a[:5] = np.arange(5)
-        >>> a.dtype
-        dtype('int64')
+        >>> import os
+        >>> assert a.dtype == np.dtype('int64') or os.name == "nt" and a.dtype == np.dtype('int32')
         >>> a = SparseArray(10)
         >>> a[:5] = torch.arange(5)
         >>> a.dtype
@@ -653,7 +656,11 @@ class SparseArray:
 
     def __getitem__(self, item):
         """
-        >>> a = zeros(20, dtype=np.int64)
+        >>> import os
+        >>> dtype = np.int64
+        >>> if os.name == "nt":
+        ...     dtype = np.int32
+        >>> a = zeros(20, dtype=dtype)
         >>> a[:10] = 1
         >>> a[15:] = np.arange(5) + 1
 

--- a/paderbox/array/sparse.py
+++ b/paderbox/array/sparse.py
@@ -715,7 +715,7 @@ class SparseArray:
           ...
         IndexError: too many indices for array: array is 2-dimensional, but 3 were indexed
         """
-        item = _normalize_item(item, self.shape)
+        item = tuple(_normalize_item(item, self.shape))
 
         assert len(item) == len(self.shape), (item, self.shape)
 

--- a/paderbox/io/atomic.py
+++ b/paderbox/io/atomic.py
@@ -126,35 +126,63 @@ def open_atomic(file, mode, *args, force=False, **kwargs):
 
     assert 'w' in mode, mode
 
-    try:
-        clean = False
-        fname = None
-        with tempfile.NamedTemporaryFile(
-                mode, *args, **kwargs, delete=False, prefix=file, dir=os.getcwd()
-        ) as tmp_f:
-            fname = tmp_f.name
+    if os.name == 'nt':
+        tmp_f = tempfile.NamedTemporaryFile(
+                    mode, *args, **kwargs, delete=False, prefix=file, dir=os.getcwd()
+            )
+        fname = tmp_f.name
 
+        def close_and_remove():
+            tmp_f.close()
+            os.unlink(fname)
+        
+        def cleanup():
+                tmp_f.flush()
+                os.fsync(tmp_f.fileno())
+                # open files cannot be accessed
+                tmp_f.close()
+                os.replace(fname, file)
+        
+        skip_close = False
+
+        try:
+            yield tmp_f
+            # skipped if exception is raised
+            if not force:
+                skip_close = True
+                cleanup()
+        except:
+            # clean up by removing temp file if exception is raised -> no partial write
+            skip_close = True
+            close_and_remove()
+            raise
+        finally:
+            #  force write, may raise error
+            if force:
+                cleanup()
+            # close file
+            if not skip_close:
+                close_and_remove()
+    else:
+        with tempfile.NamedTemporaryFile(
+            mode, *args, **kwargs, prefix=file, dir=os.getcwd()
+        ) as tmp_f:
             def cleanup():
                 tmp_f.flush()
                 os.fsync(tmp_f.fileno())
+                # os.rename(tmp_f.name, file)  # fails if dst exists
+                os.replace(tmp_f.name, file)
 
+                # Disable NamedTemporaryFile.close(), because the file was renamed.
+                tmp_f.delete = False
+                tmp_f._closer.delete = False
             try:
                 yield tmp_f
                 if not force:
-                    clean = True
                     cleanup()
             finally:
                 if force:
-                    clean = True
                     cleanup()
-    finally:
-        if clean:
-            # os.rename(fname, file)  # fails if dst exists
-            # os.replace(fname, file) # fails on windows (and not atomic on win)
-            os.remove(file)
-            os.rename(fname, file)
-        if os.path.exists(fname):
-            os.unlink(fname)
 
 
 def write_text_atomic(data: str, path):

--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -202,19 +202,19 @@ def load_audio(
             signal, sample_rate = data, f.samplerate
     except RuntimeError as e:
         if isinstance(path, (Path, str)):
-            import magic
-            # recreate the stdout of the 'file' tool
-            stdout = Path(path).as_posix() + ": " + magic.from_file(str(path)) + "\n"
+            from paderbox.utils.process_caller import run_process
+            cp = run_process(['file', f'{path}'])
+            stdout = cp.stdout
             if Path(path).suffix == '.wav':
                 # Improve exception msg for NIST SPHERE files.
                 raise RuntimeError(
-                    f'Could not read {Path(path).as_posix()}.\n' #FIXME: Adapt code to test case (posix style paths) or print platform-specific path style?
+                    f'Could not read {path}.\n'
                     f'File format:\n{stdout}'
                 ) from e
             else:
                 path = Path(path)
                 raise RuntimeError(
-                    f'Wrong suffix {path.suffix} in {Path(path).as_posix()}.\n'
+                    f'Wrong suffix {path.suffix} in {path}.\n'
                     f'File format:\n{stdout}'
                 ) from e
         raise
@@ -381,9 +381,9 @@ def audioread(path, offset=0.0, duration=None, expected_sample_rate=None):
             wav_reader.read(data)
             return np.squeeze(data), sample_rate
     except OSError as e:
-        import magic
-        # recreate the stdout of the 'file' tool
-        stdout = Path(path).as_posix() + ": " + magic.from_file(str(path)) + "\n"
+        from paderbox.utils.process_caller import run_process
+        cp = run_process(f'file {path}')
+        stdout = cp.stdout
         raise OSError(f'{stdout}') from e
 
 

--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -149,7 +149,7 @@ def load_audio(
     """
 
     # soundfile does not support pathlib.Path.
-    # ToDo: Is this sill True? # No
+    # ToDo: Is this sill True?
     path = normalize_path(path, as_str=True)
 
     if unit == 'samples':
@@ -283,7 +283,7 @@ def recursive_load_audio(
         data = [recursive_load_audio(a, **kwargs) for a in path]
 
         np_data = np.array(data)
-        if np_data.dtype != np.object:
+        if np_data.dtype != object:
             return np_data
         else:
             return data

--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -112,6 +112,9 @@ def load_audio(
 
     Examples
     --------
+    >>> import sys, pytest
+    >>> if sys.platform.startswith("win"):
+    ...     pytest.skip("Removed from windows tests")
     >>> from paderbox.io import load_audio
     >>> from paderbox.testing.testfile_fetcher import get_file_path
     >>> path = get_file_path('speech.wav')
@@ -146,7 +149,7 @@ def load_audio(
     """
 
     # soundfile does not support pathlib.Path.
-    # ToDo: Is this sill True?
+    # ToDo: Is this sill True? # No
     path = normalize_path(path, as_str=True)
 
     if unit == 'samples':

--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -429,8 +429,7 @@ def audio_channels(path):
     >>> if sys.platform.startswith("win"):
     ...     pytest.skip("`pb.io.audioread.audioread` is deprecated and "
     ...                "does not work on windows, because wavefile needs "
-    ...                "`libsndfile-1.dll`."
-    ...                "Use `pb.io.load_audio` on windows.")
+    ...                "`libsndfile-1.dll`.")
     >>> from paderbox.testing.testfile_fetcher import get_file_path
     >>> path = get_file_path('speech_source_0.wav')
     >>> audio_channels(path)
@@ -445,7 +444,11 @@ def audio_channels(path):
 
 def audio_shape(path):
     """
-
+    >>> import sys, pytest
+    >>> if sys.platform.startswith("win"):
+    ...     pytest.skip("`pb.io.audioread.audioread` is deprecated and "
+    ...                "does not work on windows, because wavefile needs "
+    ...                "`libsndfile-1.dll`.")
     >>> from paderbox.testing.testfile_fetcher import get_file_path
     >>> path = get_file_path('speech_source_0.wav')
     >>> audio_shape(path)

--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -143,7 +143,6 @@ def load_audio(
     RuntimeError: Wrong suffix .sph in ...123_1pcbe_shn.sph.
     File format:
     ...123_1pcbe_shn.sph: NIST SPHERE file
-    <BLANKLINE>
     """
 
     # soundfile does not support pathlib.Path.

--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -140,9 +140,9 @@ def load_audio(
     >>> load_audio(path)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
-    RuntimeError: Wrong suffix .sph in .../123_1pcbe_shn.sph.
+    RuntimeError: Wrong suffix .sph in ...123_1pcbe_shn.sph.
     File format:
-    .../123_1pcbe_shn.sph: NIST SPHERE file
+    ...123_1pcbe_shn.sph: NIST SPHERE file
     <BLANKLINE>
     """
 
@@ -202,9 +202,9 @@ def load_audio(
             signal, sample_rate = data, f.samplerate
     except RuntimeError as e:
         if isinstance(path, (Path, str)):
-            from paderbox.utils.process_caller import run_process
-            cp = run_process(['file', f'{path}'])
-            stdout = cp.stdout
+            import magic
+            # recreate the stdout of the 'file' tool
+            stdout = Path(path).as_posix() + ": " + magic.from_file(str(path)) + "\n"
             if Path(path).suffix == '.wav':
                 # Improve exception msg for NIST SPHERE files.
                 raise RuntimeError(

--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -204,18 +204,18 @@ def load_audio(
         if isinstance(path, (Path, str)):
             import magic
             # recreate the stdout of the 'file' tool
-            stdout = Path(path).as_posix() + ": " + magic.from_file(str(path)) + "\n"
+            msg = Path(path).as_posix() + ": " + magic.from_file(str(path))
             if Path(path).suffix == '.wav':
                 # Improve exception msg for NIST SPHERE files.
                 raise RuntimeError(
                     f'Could not read {path}.\n'
-                    f'File format:\n{stdout}'
+                    f'File format:\n{msg}'
                 ) from e
             else:
                 path = Path(path)
                 raise RuntimeError(
                     f'Wrong suffix {path.suffix} in {path}.\n'
-                    f'File format:\n{stdout}'
+                    f'File format:\n{msg}'
                 ) from e
         raise
 

--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -425,7 +425,12 @@ def audio_length(path, unit='samples'):
 
 def audio_channels(path):
     """
-
+    >>> import sys, pytest
+    >>> if sys.platform.startswith("win"):
+    ...     pytest.skip("`pb.io.audioread.audioread` is deprecated and "
+    ...                "does not work on windows, because wavefile needs "
+    ...                "`libsndfile-1.dll`."
+    ...                "Use `pb.io.load_audio` on windows.")
     >>> from paderbox.testing.testfile_fetcher import get_file_path
     >>> path = get_file_path('speech_source_0.wav')
     >>> audio_channels(path)

--- a/paderbox/io/audiowrite.py
+++ b/paderbox/io/audiowrite.py
@@ -55,13 +55,13 @@ def dump_audio(
     >>> dump_audio(a, file, normalize=False)
     >>> load_audio(file) * 2**15
     array([ 1.,  2., -4.,  4.])
-    >>> print('stdout:', get_filetype(file))  # doctest: +ELLIPSIS
+    >>> print('stdout:', run_process(f'file {file}').stdout)  # doctest: +ELLIPSIS
     stdout: .../tmp_audio_data.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 16000 Hz
     <BLANKLINE>
     >>> dump_audio(a, file, normalize=True)
     >>> load_audio(file)
     array([ 0.24996948,  0.49996948, -0.99996948,  0.99996948])
-    >>> print('stdout:', get_filetype(file))  # doctest: +ELLIPSIS
+    >>> print('stdout:', run_process(f'file {file}').stdout)  # doctest: +ELLIPSIS
     stdout: .../tmp_audio_data.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 16000 Hz
     <BLANKLINE>
 
@@ -73,14 +73,14 @@ def dump_audio(
     >>> load_audio(file)
     array([0.     , 0.03125, 0.0625 , 0.09375, 0.125  , 0.15625, 0.1875 ,
            0.21875, 0.25   , 0.28125])
-    >>> print('stdout:', get_filetype(file))  # doctest: +ELLIPSIS
+    >>> print('stdout:', run_process(f'file {file}').stdout)  # doctest: +ELLIPSIS
     stdout: .../tmp_audio_data.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 16000 Hz
     <BLANKLINE>
     >>> dump_audio(np.array([16, 24]) / 32, file, normalize=False, start=1)
     >>> load_audio(file)
     array([0.     , 0.5    , 0.75   , 0.09375, 0.125  , 0.15625, 0.1875 ,
            0.21875, 0.25   , 0.28125])
-    >>> print('stdout:', get_filetype(file))  # doctest: +ELLIPSIS
+    >>> print('stdout:', run_process(f'file {file}').stdout)  # doctest: +ELLIPSIS
     stdout: ...tmp_audio_data.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 16000 Hz
     <BLANKLINE>
     >>> dump_audio(np.array([16, 24, 24, 24]) / 32, file, normalize=False, start=9)
@@ -97,7 +97,7 @@ def dump_audio(
            0.75   , 0.75   , 0.75   ])
     >>> load_audio(file).shape
     (24,)
-    >>> print('stdout:', get_filetype(file))  # doctest: +ELLIPSIS
+    >>> print('stdout:', run_process(f'file {file}').stdout)  # doctest: +ELLIPSIS
     stdout: .../tmp_audio_data.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 16000 Hz
     <BLANKLINE>
     >>> os.remove(file)
@@ -108,7 +108,7 @@ def dump_audio(
            0.75, 0.75])
     >>> load_audio(file).shape
     (24,)
-    >>> print('stdout:', get_filetype(file))  # doctest: +ELLIPSIS
+    >>> print('stdout:', run_process(f'file {file}').stdout)  # doctest: +ELLIPSIS
     stdout: .../tmp_audio_data.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 16000 Hz
     <BLANKLINE>
 

--- a/paderbox/io/audiowrite.py
+++ b/paderbox/io/audiowrite.py
@@ -41,6 +41,10 @@ def dump_audio(
         format:
             Special option. See soundfile.SoundFile.__init__ for details.
 
+    >>> import magic
+    >>> def get_filetype(path):
+    ...     # recreate the stdout of the 'file' tool
+    ...     return Path(path).as_posix() + ": " + magic.from_file(str(path)) + "\\n"
     >>> from paderbox.utils.process_caller import run_process
     >>> from paderbox.io import load_audio
     >>> from paderbox.io.cache_dir import get_cache_dir
@@ -51,13 +55,13 @@ def dump_audio(
     >>> dump_audio(a, file, normalize=False)
     >>> load_audio(file) * 2**15
     array([ 1.,  2., -4.,  4.])
-    >>> print('stdout:', run_process(f'file {file}').stdout)  # doctest: +ELLIPSIS
+    >>> print('stdout:', get_filetype(file))  # doctest: +ELLIPSIS
     stdout: .../tmp_audio_data.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 16000 Hz
     <BLANKLINE>
     >>> dump_audio(a, file, normalize=True)
     >>> load_audio(file)
     array([ 0.24996948,  0.49996948, -0.99996948,  0.99996948])
-    >>> print('stdout:', run_process(f'file {file}').stdout)  # doctest: +ELLIPSIS
+    >>> print('stdout:', get_filetype(file))  # doctest: +ELLIPSIS
     stdout: .../tmp_audio_data.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 16000 Hz
     <BLANKLINE>
 
@@ -69,14 +73,14 @@ def dump_audio(
     >>> load_audio(file)
     array([0.     , 0.03125, 0.0625 , 0.09375, 0.125  , 0.15625, 0.1875 ,
            0.21875, 0.25   , 0.28125])
-    >>> print('stdout:', run_process(f'file {file}').stdout)  # doctest: +ELLIPSIS
+    >>> print('stdout:', get_filetype(file))  # doctest: +ELLIPSIS
     stdout: .../tmp_audio_data.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 16000 Hz
     <BLANKLINE>
     >>> dump_audio(np.array([16, 24]) / 32, file, normalize=False, start=1)
     >>> load_audio(file)
     array([0.     , 0.5    , 0.75   , 0.09375, 0.125  , 0.15625, 0.1875 ,
            0.21875, 0.25   , 0.28125])
-    >>> print('stdout:', run_process(f'file {file}').stdout)  # doctest: +ELLIPSIS
+    >>> print('stdout:', get_filetype(file))  # doctest: +ELLIPSIS
     stdout: ...tmp_audio_data.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 16000 Hz
     <BLANKLINE>
     >>> dump_audio(np.array([16, 24, 24, 24]) / 32, file, normalize=False, start=9)
@@ -93,7 +97,7 @@ def dump_audio(
            0.75   , 0.75   , 0.75   ])
     >>> load_audio(file).shape
     (24,)
-    >>> print('stdout:', run_process(f'file {file}').stdout)  # doctest: +ELLIPSIS
+    >>> print('stdout:', get_filetype(file))  # doctest: +ELLIPSIS
     stdout: .../tmp_audio_data.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 16000 Hz
     <BLANKLINE>
     >>> os.remove(file)
@@ -104,10 +108,14 @@ def dump_audio(
            0.75, 0.75])
     >>> load_audio(file).shape
     (24,)
-    >>> print('stdout:', run_process(f'file {file}').stdout)  # doctest: +ELLIPSIS
+    >>> print('stdout:', get_filetype(file))  # doctest: +ELLIPSIS
     stdout: .../tmp_audio_data.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 16000 Hz
     <BLANKLINE>
 
+    >>> import sys, pytest
+    >>> if sys.platform.startswith("win"):
+    ...     pytest.skip("soxi is not available on Windows."
+    ...                "Use `pb.io.load_audio` on windows.")
     >>> data = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) / 32
     >>> data
     array([0.     , 0.03125, 0.0625 , 0.09375, 0.125  , 0.15625, 0.1875 ,

--- a/paderbox/io/audiowrite.py
+++ b/paderbox/io/audiowrite.py
@@ -41,10 +41,6 @@ def dump_audio(
         format:
             Special option. See soundfile.SoundFile.__init__ for details.
 
-    >>> import magic
-    >>> def get_filetype(path):
-    ...     # recreate the stdout of the 'file' tool
-    ...     return Path(path).as_posix() + ": " + magic.from_file(str(path)) + "\\n"
     >>> from paderbox.utils.process_caller import run_process
     >>> from paderbox.io import load_audio
     >>> from paderbox.io.cache_dir import get_cache_dir

--- a/paderbox/io/data_dir.py
+++ b/paderbox/io/data_dir.py
@@ -1,17 +1,3 @@
-"""
-
->>> from pathlib import Path
->>> p = Path('/') / 'net' # /storage/python_unittest_data
->>> p
-PosixPath('/net')
->>> p = p / 'storage'
->>> p
-PosixPath('/net/storage')
->>> str(p)
-'/net/storage'
-
-"""
-
 import os
 from pathlib import Path
 import urllib.request as url

--- a/paderbox/io/hdf5.py
+++ b/paderbox/io/hdf5.py
@@ -1,4 +1,5 @@
 import os
+import re
 import warnings
 
 import numpy as np
@@ -9,10 +10,9 @@ from distutils.version import LooseVersion
 __all__ = ['dump_hdf5', 'update_hdf5', 'load_hdf5']
 
 def join_paths(path, name):
-    """Join paths using '/', removing one or adding one forward slash if necessary.
+    """Join paths using '/', removing duplicate forward slashes if necessary.
     
-    This is different from os.path.join, which adds '\\' on Windows systems.
-    The function will not check for duplicate slashes in the input paths (e.g. "/a//").
+    This is different from os.path.join, which adds '\\' on Windows.
 
     Args:
         path:
@@ -23,34 +23,8 @@ def join_paths(path, name):
     Returns:
         path concatenated with name using a single '/'
     
-
-    >>> join_paths("/a", "b")
-    '/a/b'
-    >>> join_paths("/", "/a")
-    '/a'
-    >>> join_paths("", "/a")
-    '/a'
-    >>> join_paths("/a", "")
-    '/a'
-    >>> join_paths("/a", "/") # case not considered
-    '/a/'
     """
-    if len(path) == 0:
-        return name
-    if len(name) == 0:
-        return path
-    suffix = False
-    if path[-1] == '/':
-        suffix = True
-    prefix = False
-    if name[0] == '/':
-        prefix = True
-    if suffix and prefix:
-        path += name[1:] 
-    elif suffix or prefix:
-        path += name
-    else:
-        path += '/' + name
+    path = re.sub('/+', '/', name if name.startswith('/') else f'{path}/{name}')
     return path
 
 

--- a/paderbox/io/hdf5.py
+++ b/paderbox/io/hdf5.py
@@ -510,7 +510,7 @@ class _ReportInterface(object):
                     # handling after version 3.0.0 to dumping strings as bytes
                     if LooseVersion(h5py.__version__) >= '3.0.0':
                         ans[key] = ans[key].decode()
-                if ans[key] == 'None':
+                if isinstance(ans[key], str) and ans[key] == 'None':
                     ans[key] = None
 
             elif isinstance(item, h5py._hl.group.Group):

--- a/paderbox/io/new_subdir.py
+++ b/paderbox/io/new_subdir.py
@@ -84,16 +84,16 @@ def get_new_subdir(
     Returns:
         pathlib.Path of the new subdir
 
-
-    >>> get_new_subdir('/', dry_run=True)  # root folder usually contain no digits
-    dry_run: "os.mkdir(/1)"
-    PosixPath('/1')
+    >>> # root folder usually contain no digits
+    >>> get_new_subdir('/', dry_run=True)    # doctest: +ELLIPSIS
+    dry_run: "os.mkdir(...1)"
+    ...Path('...1')
 
     >>> import numpy as np
     >>> np.random.seed(0)  # This is for doctest. Never use it in practise.
-    >>> get_new_subdir('/', id_naming=NameGenerator(), dry_run=True)
-    dry_run: "os.mkdir(/nice_tomato_fox)"
-    PosixPath('/nice_tomato_fox')
+    >>> get_new_subdir('/', id_naming=NameGenerator(), dry_run=True)  # doctest: +ELLIPSIS
+    dry_run: "os.mkdir(...nice_tomato_fox)"
+    ...Path('...nice_tomato_fox')
     """
 
     if consider_mpi:

--- a/paderbox/io/wrapper_load.py
+++ b/paderbox/io/wrapper_load.py
@@ -244,7 +244,7 @@ def load(
     Traceback (most recent call last):
     ...
     AssertionError: You called Loader.__call__ with unsafe=False
-    ...
+    for the file ...unsecure_file.pkl.
     The file type is identified as '.pkl'.
     Loading this file type is not secure.
     If you trust the file, change the value of unsafe to True.

--- a/paderbox/io/wrapper_load.py
+++ b/paderbox/io/wrapper_load.py
@@ -240,11 +240,11 @@ def load(
 
 
     To load an unsecure, you have to change `unsafe` to `True`
-    >>> load('/path/to/unsecure_file.pkl', unsafe=False)
+    >>> load('/path/to/unsecure_file.pkl', unsafe=False)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
     AssertionError: You called Loader.__call__ with unsafe=False
-    for the file /path/to/unsecure_file.pkl.
+    ...
     The file type is identified as '.pkl'.
     Loading this file type is not secure.
     If you trust the file, change the value of unsafe to True.
@@ -254,7 +254,7 @@ def load(
       execute arbitrary code during unpickling. Never unpickle
       data that could have come from an untrusted source, or that
       could have been tampered with.
-
+    
     """
     loader = Loader(
         ignore_type_error=ignore_type_error,

--- a/paderbox/io/yaml_module.py
+++ b/paderbox/io/yaml_module.py
@@ -93,14 +93,15 @@ def dump_yaml_unsafe(
         **kwargs:
 
     >>> d = {'a': [1, 2], 'b': (3, 4), 'p': Path('abc')}
-    >>> print(dumps_yaml_unsafe(d))
+    >>> # allow both PosixPath and WindowsPath in this test
+    >>> print(dumps_yaml_unsafe(d))  # doctest: +ELLIPSIS
     a:
     - 1
     - 2
     b: !!python/tuple
     - 3
     - 4
-    p: !!python/object/apply:pathlib.PosixPath
+    p: !!python/object/apply:pathlib...Path
     - abc
     <BLANKLINE>
 

--- a/paderbox/transform/module_resample.py
+++ b/paderbox/transform/module_resample.py
@@ -24,6 +24,11 @@ def resample_sox(signal: np.ndarray, *, in_rate, out_rate):
     SoX automatically does a delay compensation and uses linear filters. This
     is already a sane choice.
 
+    >>> import sys, pytest
+    >>> if sys.platform.startswith("win"):
+    ...     pytest.skip("`pb.transform.module_resample.resample_sox` only works "
+    ...                "on windows if `SoX` is installed, tests are skipped.")
+
     >>> signal = np.array([1, -1, 1, -1], dtype=np.float32)
     >>> resample_sox(signal, in_rate=2, out_rate=1)
     array([ 0.28615332, -0.13513082], dtype=float32)

--- a/paderbox/transform/module_stft.py
+++ b/paderbox/transform/module_stft.py
@@ -250,8 +250,8 @@ def _samples_to_stft_frames(
     9
 
     >>> result_arr = _samples_to_stft_frames(np.array([19, 20, 21]), 16, 4, fading='full')
-    >>> print(str(result_arr), result_arr.dtype) #  avoid numpy repr inconsistencies on Windows
-    [8 8 9] int32
+    >>> print(str(result_arr)) #  avoid numpy repr inconsistencies on Windows
+    [8 8 9]
 
     >>> stft(np.zeros(19), 16, 4).shape
     (8, 9)

--- a/paderbox/transform/module_stft.py
+++ b/paderbox/transform/module_stft.py
@@ -249,8 +249,9 @@ def _samples_to_stft_frames(
     >>> _samples_to_stft_frames(21, 16, 4, fading='full')
     9
 
-    >>> _samples_to_stft_frames(np.array([19, 20, 21]), 16, 4, fading='full')
-    array([8, 8, 9])
+    >>> result_arr = _samples_to_stft_frames(np.array([19, 20, 21]), 16, 4, fading='full')
+    >>> print(str(result_arr), result_arr.dtype) #  avoid numpy repr inconsistencies on Windows
+    [8 8 9] int32
 
     >>> stft(np.zeros(19), 16, 4).shape
     (8, 9)
@@ -420,8 +421,9 @@ def stft_frame_index_to_sample_index(
     799
     >>> stft_frame_index_to_sample_index(-1, 400, 160, mode='last', fading=None, num_samples=800)
     799
-    >>> stft_frame_index_to_sample_index(3, 400, 160, mode='last', pad=False, fading=None, num_samples=800)
+    >>> stft_frame_index_to_sample_index(3, 400, 160, mode='last', pad=False, fading=None, num_samples=800)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
+    ...
     AssertionError: (3, 3)
     >>> stft_frame_index_to_sample_index(np.array([1]), 400, 160, mode='center', fading='full')
     array([120])

--- a/paderbox/transform/module_stft.py
+++ b/paderbox/transform/module_stft.py
@@ -68,7 +68,7 @@ def stft(
     # Pad with zeros to have enough samples for the window function to fade.
     assert fading in [None, True, False, 'full', 'half'], fading
     if fading not in [False, None]:
-        pad_width = np.zeros((time_signal.ndim, 2), dtype=np.int)
+        pad_width = np.zeros((time_signal.ndim, 2), dtype=int)
         if fading == 'half':
             pad_width[axis, 0] = (window_length - shift) // 2
             pad_width[axis, 1] = ceil((window_length - shift) / 2)
@@ -394,7 +394,7 @@ def stft_frame_index_to_sample_index(
         shift: stft hop size
         pad: True if stft uses padding else False
         fading: fading used in stft
-        mode: states the sample to return \in {'first','center','last'}.
+        mode: states the sample to return in {'first','center','last'}.
             With 'center' the higher sample index is returned when center lies
             between two samples. Default is 'center'.
         num_samples: total number of samples in the source signal.

--- a/paderbox/utils/numpy_utils.py
+++ b/paderbox/utils/numpy_utils.py
@@ -23,7 +23,7 @@ def to_ndarray(data, copy=True):
 
 def labels_to_one_hot(
         labels: np.ndarray, categories: int, axis: int = 0,
-        keepdims=False, dtype=np.bool
+        keepdims=False, dtype=bool
 ):
     """ Translates an arbitrary ndarray with labels to one hot coded array.
 

--- a/paderbox/utils/pretty.py
+++ b/paderbox/utils/pretty.py
@@ -71,8 +71,8 @@ def pprint(
      - Support multiple objects (Causes bad readable error in original)
 
 
-    >>> pprint([np.array([1]), np.array([1]*100).astype(np.int64)])
-    [array([1]), array(shape=(100,), dtype=int64)]
+    >>> pprint([np.array([1.]), np.array([1.]*100)])
+    [array([1]), array(shape=(100,), dtype=float64)]
     >>> print([np.array([1])])
     [array([1])]
 

--- a/paderbox/utils/pretty.py
+++ b/paderbox/utils/pretty.py
@@ -72,7 +72,7 @@ def pprint(
 
 
     >>> pprint([np.array([1.]), np.array([1.]*100)])
-    [array([1]), array(shape=(100,), dtype=float64)]
+    [array([1.]), array(shape=(100,), dtype=float64)]
     >>> print([np.array([1])])
     [array([1])]
 

--- a/paderbox/utils/pretty.py
+++ b/paderbox/utils/pretty.py
@@ -71,7 +71,7 @@ def pprint(
      - Support multiple objects (Causes bad readable error in original)
 
 
-    >>> pprint([np.array([1]), np.array([1]*100)])
+    >>> pprint([np.array([1]), np.array([1]*100).astype(np.int64)])
     [array([1]), array(shape=(100,), dtype=int64)]
     >>> print([np.array([1])])
     [array([1])]

--- a/paderbox/utils/process_caller.py
+++ b/paderbox/utils/process_caller.py
@@ -96,16 +96,16 @@ def run_process(
     >>> run_process('echo Hello')
     CompletedProcess(args='echo Hello', returncode=0, stdout='Hello\\n', stderr='')
     >>> run_process('echo Hello', universal_newlines=False)
-    CompletedProcess(args='echo Hello', returncode=0, stdout=b'Hello\\n', stderr=b'') ##additional \r in stdout bytes
+    CompletedProcess(args='echo Hello', returncode=0, stdout=b'Hello\\n', stderr=b'')
 
     # Example, where shell=False is usefull
-    >>> run_process(['echo', 'Hello World']) ## file not found error
+    >>> run_process(['echo', 'Hello World'])
     CompletedProcess(args=['echo', 'Hello World'], returncode=0, stdout='Hello World\\n', stderr='')
-    >>> run_process(['echo', 'Hello World'], shell=True)  # fails ## "Hello World" is printed to stdout
+    >>> run_process(['echo', 'Hello World'], shell=True)  # fails
     CompletedProcess(args=['echo', 'Hello World'], returncode=0, stdout='\\n', stderr='')
-    >>> run_process('echo', shell=True) ## a single echo prints "ECHO is on." to stdout
+    >>> run_process('echo', shell=True)
     CompletedProcess(args='echo', returncode=0, stdout='\\n', stderr='')
-    >>> run_process(['echo', 'Hello World'], shell=False) ## file not found (hello world command?)
+    >>> run_process(['echo', 'Hello World'], shell=False)
     CompletedProcess(args=['echo', 'Hello World'], returncode=0, stdout='Hello World\\n', stderr='')
 
 
@@ -200,7 +200,7 @@ async def run_process_async(
 
     # Effect of universal_newlines
     >>> run_process('echo Hello')
-    CompletedProcess(args='echo Hello', returncode=0, stdout='Hello\\n', stderr='') ## additional \r char
+    CompletedProcess(args='echo Hello', returncode=0, stdout='Hello\\n', stderr='')
     >>> convert_newlines(run_process('echo Hello', universal_newlines=False))
     CompletedProcess(args='echo Hello', returncode=0, stdout=b'Hello\\n', stderr=b'')
 
@@ -208,14 +208,14 @@ async def run_process_async(
     >>> # run_process('echo Hello', stdout=None)
 
     # Example, where shell=False is usefull
-    >>> run_process(['echo', 'Hello World']) ## file not found, hello world command? echo not on PATH
+    >>> run_process(['echo', 'Hello World'])
     CompletedProcess(args=['echo', 'Hello World'], returncode=0, stdout='Hello World\\n', stderr='')
     >>> run_process(['echo', 'Hello World'], shell=True)
     Traceback (most recent call last):
     ...
     ValueError: ('Expected str and not list when shell is True, got:', ['echo', 'Hello World'])
     >>> run_process(['echo', 'Hello World'], shell=False)
-    CompletedProcess(args=['echo', 'Hello World'], returncode=0, stdout='Hello World\\n', stderr='') ## file not found error, hello world command
+    CompletedProcess(args=['echo', 'Hello World'], returncode=0, stdout='Hello World\\n', stderr='')
 
     >>> run_process('exit 0')
     CompletedProcess(args='exit 0', returncode=0, stdout='', stderr='')

--- a/paderbox/utils/process_caller.py
+++ b/paderbox/utils/process_caller.py
@@ -258,7 +258,6 @@ async def run_process_async(
         else:
             process = await asyncio.create_subprocess_shell(cmd, **kwargs)
     else:
-        raise ValueError(*cmd)
         process = await asyncio.create_subprocess_exec(*cmd, **kwargs)
     stdout, stderr = await process.communicate(input=input)
 

--- a/paderbox/utils/process_caller.py
+++ b/paderbox/utils/process_caller.py
@@ -201,7 +201,7 @@ async def run_process_async(
     # Effect of universal_newlines
     >>> run_process('echo Hello')
     CompletedProcess(args='echo Hello', returncode=0, stdout='Hello\\n', stderr='')
-    >>> convert_newlines(run_process('echo Hello', universal_newlines=False))
+    >>> run_process('echo Hello', universal_newlines=False)
     CompletedProcess(args='echo Hello', returncode=0, stdout=b'Hello\\n', stderr=b'')
 
     >>> # This would print 'Hello' to stdout. Doctests cannot handle this case.

--- a/paderbox/utils/timer.py
+++ b/paderbox/utils/timer.py
@@ -85,7 +85,7 @@ class TimerDict:
     """
     >>> t = TimerDict()
     >>> with t['test']:
-    ...     time.sleep(1)
+    ...     time.sleep(1.01)  # make sure the time is correct
     >>> with t['test']:
     ...     time.sleep(1)
     >>> with t['test_2']:

--- a/paderbox/utils/timer.py
+++ b/paderbox/utils/timer.py
@@ -83,25 +83,26 @@ class TimerDictEntry:
 
 class TimerDict:
     """
+    >>> eps = 0.01  # make sure the time is correct
     >>> t = TimerDict()
     >>> with t['test']:
-    ...     time.sleep(1.01)  # make sure the time is correct
+    ...     time.sleep(1 + eps)
     >>> with t['test']:
-    ...     time.sleep(1)
+    ...     time.sleep(1 + eps)
     >>> with t['test_2']:
-    ...     time.sleep(1)
+    ...     time.sleep(1 + eps)
 
     # Wrap iterator
     >>> def slow_range(N):
     ...     for i in range(N):
-    ...         time.sleep(0.1)
+    ...         time.sleep(0.1 + eps)
     ...         yield i
     >>> for i in t['test_3'](slow_range(3)):
     ...    pass
 
     # Nesting
     >>> with t['test_4']:
-    ...     time.sleep(1)
+    ...     time.sleep(1 + eps)
     ...     with t['test_4']:
     ...         pass
 

--- a/paderbox/visualization/tikz.py
+++ b/paderbox/visualization/tikz.py
@@ -57,7 +57,7 @@ def resize_svg_code(
         return str(code_bs.svg)
 
     elif method == 'regex':
-        m = re.fullmatch('(.*svg width=")(\d*)(pt" height=")(\d*)(pt".*)',
+        m = re.fullmatch(r'(.*svg width=")(\d*)(pt" height=")(\d*)(pt".*)',
                          code,
                          re.DOTALL)
         g = list(m.groups())
@@ -210,7 +210,7 @@ def plot_to_tikz_embedded_png(
         name, png_path=pathlib.Path('.'), tikz_path=pathlib.Path('.'),
         tex_image_prefix='images', width='\\plotwidth', xlabel='', ylabel='',
         colors='', additional_tikz_content='', dpi=300):
-    """
+    r"""
     Creates a tikz file that has a png image as background that is created using
     the current matplotlib figure.
 

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
         "dataclasses; python_version<'3.7'",  # dataclasses is in py37 buildin
         'soundfile',
         'cached_property',
-        'magic'
+        'python-magic'
     ],
 
     # Installation problems in a clean, new environment:

--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,7 @@ setup(
         "dataclasses; python_version<'3.7'",  # dataclasses is in py37 buildin
         'soundfile',
         'cached_property',
+        'magic'
     ],
 
     # Installation problems in a clean, new environment:

--- a/tests/io_tests/test_audiowrite.py
+++ b/tests/io_tests/test_audiowrite.py
@@ -1,17 +1,24 @@
-import numpy
-import numpy.testing as nptest
+import sys
+import pytest
 import unittest
 import os
 import time
 from paderbox.io.audioread import audioread
 from paderbox.io.audiowrite import audiowrite
 
+import numpy
+import numpy.testing as nptest
+
 signal = numpy.random.uniform(-1, 1, size=(10000,))
 path = 'audiowrite_test.wav'
 
 int16_max = numpy.iinfo(numpy.int16).max
 
-
+@pytest.mark.skip(
+    sys.platform.startswith("win"),
+    reason="`pb.io.audioread.audioread` is deprecated and does not work on"
+           "windows, because wavefile needs `libsndfile-1.dll`."
+           "Use `pb.io.load_audio` on windows.")
 class AudioWriteTest(unittest.TestCase):
 
     def test_write_read_float(self):

--- a/tests/io_tests/test_dump_load_audio.py
+++ b/tests/io_tests/test_dump_load_audio.py
@@ -95,8 +95,8 @@ class TestIOAudio:
     [
         ('speech.sph', False),
         ('123_2alaw.sph', False),
-        ('123_1pcle_shn.sph', True),
-        ('123_1ulaw_shn.sph', True),
+        #('123_1pcle_shn.sph', True),
+        #('123_1ulaw_shn.sph', True),
     ])
     def test_sph_files(self, file, fails):
         # Some SPHERE files can be read with soundfile, but not all.

--- a/tests/io_tests/test_dump_load_audio.py
+++ b/tests/io_tests/test_dump_load_audio.py
@@ -1,4 +1,5 @@
 import io
+from os import system
 
 import numpy as np
 import soundfile
@@ -91,13 +92,15 @@ class TestIOAudio:
         content = io.BytesIO(dumps_audio(a, dtype=dump_type, normalize=False))
         c = load_audio(content, dtype=load_type)
 
-    @pytest.mark.parametrize("file,fails",
-    [
+    sph_examples = [
         ('speech.sph', False),
         ('123_2alaw.sph', False),
-        #('123_1pcle_shn.sph', True),
-        #('123_1ulaw_shn.sph', True),
-    ])
+    ]
+    import sys
+    if not sys.platform.startswith("win"):
+        sph_examples.extend([('123_1pcle_shn.sph', True),
+                             ('123_1ulaw_shn.sph', True)])
+    @pytest.mark.parametrize("file,fails", sph_examples)
     def test_sph_files(self, file, fails):
         # Some SPHERE files can be read with soundfile, but not all.
         path = get_file_path(file)

--- a/tests/io_tests/test_hdf5.py
+++ b/tests/io_tests/test_hdf5.py
@@ -9,12 +9,12 @@ from paderbox.io import dump_hdf5, load_hdf5
 class TestHdf5:
     @pytest.mark.skipif(os.name == 'nt', reason="Numpy default integer types differ on Windows.")
     @pytest.mark.parametrize("name,data,expect", [
-        ('int', {'key': 1}, np.int32(1)),
+        ('int', {'key': 1}, np.int64(1)),
         ('float', {'key': 1.1}, np.float64(1.1)),
         ('complex', {'key': 1.1j}, np.complex128(1.1j)),
         ('str', {'key': 'bla'}, 'bla'),
         ('none', {'key': None}, None),
-        ('np int', {'key': np.int64(1)}, np.int64(1)),
+        ('np int', {'key': np.int(1)}, np.int64(1)),
         ('np float32', {'key': np.float32(1.1)}, np.float32(1.1)),
         ('np float64', {'key': np.float64(1.1)}, np.float64(1.1)),
         ('np complex64', {'key': np.complex64(1.1j)}, np.complex64(1.1j)),

--- a/tests/io_tests/test_hdf5.py
+++ b/tests/io_tests/test_hdf5.py
@@ -13,7 +13,7 @@ class TestHdf5:
         ('complex', {'key': 1.1j}, np.complex128(1.1j)),
         ('str', {'key': 'bla'}, 'bla'),
         ('none', {'key': None}, None),
-        ('np int', {'key': np.int(1)}, np.int32(1) if os.name == 'nt' else np.int64(1)),
+        ('np int', {'key': int(1)}, np.int32(1) if os.name == 'nt' else np.int64(1)),
         ('np float32', {'key': np.float32(1.1)}, np.float32(1.1)),
         ('np float64', {'key': np.float64(1.1)}, np.float64(1.1)),
         ('np complex64', {'key': np.complex64(1.1j)}, np.complex64(1.1j)),

--- a/tests/io_tests/test_hdf5.py
+++ b/tests/io_tests/test_hdf5.py
@@ -7,14 +7,13 @@ from paderbox.io import dump_hdf5, load_hdf5
 
 
 class TestHdf5:
-    @pytest.mark.skipif(os.name == 'nt', reason="Numpy default integer types differ on Windows.")
     @pytest.mark.parametrize("name,data,expect", [
-        ('int', {'key': 1}, np.int64(1)),
+        ('int', {'key': 1}, np.int32(1) if os.name == 'nt' else np.int64(1)), #  numpy default integer type on Windows is always int32.
         ('float', {'key': 1.1}, np.float64(1.1)),
         ('complex', {'key': 1.1j}, np.complex128(1.1j)),
         ('str', {'key': 'bla'}, 'bla'),
         ('none', {'key': None}, None),
-        ('np int', {'key': np.int(1)}, np.int64(1)),
+        ('np int', {'key': np.int(1)}, np.int32(1) if os.name == 'nt' else np.int64(1)),
         ('np float32', {'key': np.float32(1.1)}, np.float32(1.1)),
         ('np float64', {'key': np.float64(1.1)}, np.float64(1.1)),
         ('np complex64', {'key': np.complex64(1.1j)}, np.complex64(1.1j)),

--- a/tests/io_tests/test_hdf5.py
+++ b/tests/io_tests/test_hdf5.py
@@ -7,13 +7,14 @@ from paderbox.io import dump_hdf5, load_hdf5
 
 
 class TestHdf5:
+    @pytest.mark.skipif(os.name == 'nt', reason="Numpy default integer types differ on Windows.")
     @pytest.mark.parametrize("name,data,expect", [
-        ('int', {'key': 1}, np.int64(1)),
+        ('int', {'key': 1}, np.int32(1)),
         ('float', {'key': 1.1}, np.float64(1.1)),
         ('complex', {'key': 1.1j}, np.complex128(1.1j)),
         ('str', {'key': 'bla'}, 'bla'),
         ('none', {'key': None}, None),
-        ('np int', {'key': np.int(1)}, np.int64(1)),
+        ('np int', {'key': np.int64(1)}, np.int64(1)),
         ('np float32', {'key': np.float32(1.1)}, np.float32(1.1)),
         ('np float64', {'key': np.float64(1.1)}, np.float64(1.1)),
         ('np complex64', {'key': np.complex64(1.1j)}, np.complex64(1.1j)),

--- a/tests/transform_tests/test_fbank.py
+++ b/tests/transform_tests/test_fbank.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from paderbox.io.audioread import audioread
+from paderbox.io import load_audio
 # from scipy import signal
 
 import paderbox.testing as tc
@@ -16,7 +16,7 @@ class TestSTFTMethods(unittest.TestCase):
     def test_fbank(self):
         path = get_file_path("sample.wav")
 
-        y = audioread(path)[0]
+        y = load_audio(path)
         feature = transform.fbank(y)
 
         tc.assert_equal(feature.shape, (240, 23))

--- a/tests/transform_tests/test_filter.py
+++ b/tests/transform_tests/test_filter.py
@@ -1,6 +1,6 @@
 import unittest
 
-from paderbox.io.audioread import audioread
+from paderbox.io import load_audio
 # from scipy import signal
 
 import paderbox.testing as tc
@@ -15,7 +15,7 @@ class TestSTFTMethods(unittest.TestCase):
     def setUpClass(self):
         path = get_file_path("sample.wav")
 
-        self.x = audioread(path)[0]
+        self.x = load_audio(path)
 
     def test_offcomp(self):
         y = self.x

--- a/tests/transform_tests/test_mfcc.py
+++ b/tests/transform_tests/test_mfcc.py
@@ -1,6 +1,6 @@
 import unittest
 
-from paderbox.io.audioread import audioread
+from paderbox.io import load_audio
 # from scipy import signal
 
 import paderbox.testing as tc
@@ -14,7 +14,7 @@ class TestSTFTMethods(unittest.TestCase):
     def test_mfcc(self):
         path = get_file_path("sample.wav")
 
-        y = audioread(path)[0]
+        y = load_audio(path)
         y_filtered = transform.mfcc(y)
 
         tc.assert_equal(y_filtered.shape, (291, 13))

--- a/tests/transform_tests/test_ssc.py
+++ b/tests/transform_tests/test_ssc.py
@@ -1,6 +1,6 @@
 import unittest
 
-from paderbox.io.audioread import audioread
+from paderbox.io import load_audio
 # from scipy import signal
 
 import paderbox.testing as tc
@@ -16,7 +16,7 @@ class TestSTFTMethods(unittest.TestCase):
     def test_mfcc(self):
         path = get_file_path("sample.wav")
 
-        y = audioread(path)[0]
+        y = load_audio(path)
         yFilterd = transform.ssc(y)
 
         tc.assert_equal(yFilterd.shape, (294, 26))

--- a/tests/transform_tests/test_stft.py
+++ b/tests/transform_tests/test_stft.py
@@ -5,7 +5,7 @@ from scipy import signal
 
 import paderbox.testing as tc
 from paderbox.testing.testfile_fetcher import get_file_path
-from paderbox.io.audioread import audioread
+from paderbox.io import load_audio
 from paderbox.transform.module_stft import _biorthogonal_window
 from paderbox.transform.module_stft import _biorthogonal_window_loopy
 from paderbox.transform.module_stft import _biorthogonal_window_brute_force
@@ -74,7 +74,7 @@ class TestSTFTMethods(unittest.TestCase):
 
     def setUp(self):
         path = get_file_path("sample.wav")
-        self.x = audioread(path)[0]
+        self.x = load_audio(path)
 
     def test_samples_to_stft_frames(self):
         size = 1024

--- a/tests/utils_test/test_process_caller.py
+++ b/tests/utils_test/test_process_caller.py
@@ -1,3 +1,5 @@
+import sys
+
 import paderbox.utils.process_caller as pc
 import unittest
 
@@ -7,7 +9,10 @@ class ProcessCallerTest(unittest.TestCase):
         cmds = 5*['echo "Test"']
         stdout, stderr, ret_codes = pc.run_processes(cmds)
         for out in stdout:
-            self.assertEqual(out, 'Test\n')
+            if sys.platform.startswith("win"):
+                self.assertEqual(out, '"Test"\n')
+            else:
+                self.assertEqual(out, 'Test\n')
         for err in stderr:
             self.assertEqual(err, '')
         for code in ret_codes:
@@ -19,7 +24,10 @@ class ProcessCallerTest(unittest.TestCase):
         for out in stdout:
             self.assertEqual(out, '')
         for err in stderr:
-            self.assertEqual(err, 'Test\n')
+            if sys.platform.startswith("win"):
+                self.assertEqual(err, '"Test" \n')
+            else:
+                self.assertEqual(err, 'Test\n')
         for code in ret_codes:
             self.assertEqual(code, 0)
 


### PR DESCRIPTION
Adds Windows test environment and modifies or skips tests if necessary.
The most important differences between the systems are:
Tests now allow for WindowsPath objects or backward instead of only forward slashes.
The default numpy integer type is np.int32 on Windows with 64bit Python, instead of np.int64.
Atomic writes are not possible using the os module and modifiying an opened file results in a PermissionError.
Creating processes with the subprocess module produces different outputs since a Windows newline is '\r\n', not '\n' and commands like 'echo' are not found with 'shell=False'.