### PR TITLE
Add workflow for Windows wheels

### DIFF
--- a/.github/workflows/wheels_windows.yml
+++ b/.github/workflows/wheels_windows.yml
@@ -1,0 +1,49 @@
+name: Build CI wheels for windows
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+  # Save CI by only running this on release branches or tags.
+  push:
+    branches:
+      - v[0-9]+.[0-9]+.x
+    tags:
+      - v*
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: [windows]
+        python-version: ['6', '7', '8', '9']  # , '10' # 3.10 does not work
+        cibw_archs: ["auto"]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.8'
+      
+      # - name: Install numpy
+      #   run: pip install numpy==1.22.1  # latest release
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel
+
+      - name: Build wheels for CPython 3.${{ matrix.python-version }}
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: 'cp3${{ matrix.python-version }}-*'
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_PLATFORM: '${{ matrix.os }}'
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./dist/*.whl

--- a/maintenance.md
+++ b/maintenance.md
@@ -18,6 +18,8 @@ pip install --upgrade bump2version
 
 `bump2version` takes care to increase the version number, create the commit and tag.
 
+To add the wheels for Windows to the release, trigger the wheels_windows pipeline on Github (via the web UI or by creating a version tag) and download the wheels into the dist/ directory.
+
 ```bash
 bump2version --verbose --tag patch  # major, minor or patch
 python setup.py sdist  # bdist_wheel  # It is difficult to get bdist_wheel working with binary files

--- a/tests/io_tests/test_audiowrite.py
+++ b/tests/io_tests/test_audiowrite.py
@@ -14,7 +14,7 @@ path = 'audiowrite_test.wav'
 
 int16_max = numpy.iinfo(numpy.int16).max
 
-@pytest.mark.skip(
+@pytest.mark.skipif(
     sys.platform.startswith("win"),
     reason="`pb.io.audioread.audioread` is deprecated and does not work on"
            "windows, because wavefile needs `libsndfile-1.dll`."


### PR DESCRIPTION
Adds github workflow generating wheels for Windows.
The pipeline can be triggered via the github UI ('workflow_dispatch') or is automatically started on version tags or branches.
Wheels are created for 32 and 64 bit Windows and for Python 3.6, 3.7, 3.8 and 3.9

For wheels created by the workflow see: https://github.com/alexanderwerning/paderbox/actions/runs/1887543159