### PR TITLE
Small fixes and improvements

### DIFF
--- a/paderbox/array/interval/rttm.py
+++ b/paderbox/array/interval/rttm.py
@@ -168,7 +168,7 @@ def to_rttm_str(data, sample_rate=16000):
             content = data[file_id][name]
             if isinstance(content, np.ndarray):
                 content = ArrayInterval(content)
-            for begin, end in content.intervals:
+            for begin, end in content.normalized_intervals:
                 duration = decimal.Decimal(int(end - begin)) / sample_rate
                 begin = decimal.Decimal(int(begin)) / sample_rate
                 lines.append(

--- a/paderbox/io/cache_loader.py
+++ b/paderbox/io/cache_loader.py
@@ -9,11 +9,11 @@ import contextlib
 import paderbox as pb
 
 
-def check(cache_dir):
+def check(cache_dir, keepfree_gigabytes=5):
     # copied from lazy_dataset.core.DiskCacheDataset
     import shutil
     diskusage = shutil.disk_usage(cache_dir)
-    if diskusage.free < 5 * 1024 ** 3:
+    if diskusage.free < keepfree_gigabytes * 1024 ** 3:
         import warnings
         import humanfriendly
         warnings.warn(

--- a/paderbox/io/wrapper_dump.py
+++ b/paderbox/io/wrapper_dump.py
@@ -95,7 +95,7 @@ def dump(
             from paderbox.io.yaml_module import dump_yaml
             dump_yaml(obj, path, **kwargs)
     elif str(path).endswith(".gz"):
-        assert len(kwargs) == 0, kwargs
+        # assert len(kwargs) == 0, kwargs
         with gzip.GzipFile(path, 'wb', compresslevel=1) as f:
             if str(path).endswith(".json.gz"):
                 f.write(json.dumps(obj).encode())
@@ -104,9 +104,20 @@ def dump(
                 pickle.dump(obj, f, protocol=pickle.HIGHEST_PROTOCOL)
             elif str(path).endswith(".npy.gz"):
                 np.save(f, obj, allow_pickle=unsafe)
+            elif str(path).endswith(".wav.gz") or str(path).endswith(".flac.gz"):
+                from paderbox.io import dump_audio
+                if np.ndim(obj) == 1:
+                    pass
+                elif np.ndim(obj) == 2:
+                    assert np.shape(obj)[0] < 20, (np.shape(obj), obj)
+                else:
+                    raise AssertionError(('Expect ndim in [1, 2]', np.shape(obj), obj))
+                with path.open("wb") as fp:  # Throws better exception msg
+                    fp.name = path.with_suffix('')  # Remove .gz from the name.
+                    dump_audio(obj, fp, **kwargs)
             else:
                 raise ValueError(path)
-    elif str(path).endswith(".wav"):
+    elif str(path).endswith(".wav") or str(path).endswith(".flac"):
         from paderbox.io import dump_audio
         if np.ndim(obj) == 1:
             pass

--- a/paderbox/io/wrapper_load.py
+++ b/paderbox/io/wrapper_load.py
@@ -97,13 +97,13 @@ class Loader:
 
             with gzip.GzipFile(**gzip_file, mode='rb') as f:
                 if ext == '.json.gz':
-                    return json.loads(f.read().decode())
+                    return json.loads(f.read().decode(), **self.kwargs)
                 elif ext == '.pkl.gz':
                     assert self.unsafe, self._unsafe_msg(self.unsafe, file, ext)
-                    return pickle.load(f)
+                    return pickle.load(f, **self.kwargs)
                 elif ext == '.npy.gz':
                     assert self.unsafe, (self.unsafe, file)
-                    return np.load(f, allow_pickle=self.unsafe)
+                    return np.load(f, allow_pickle=self.unsafe, **self.kwargs)
                 elif ext == '.wav.gz':
                     from paderbox.io import load_audio
                     return load_audio(f, **self.kwargs)

--- a/paderbox/io/wrapper_load.py
+++ b/paderbox/io/wrapper_load.py
@@ -86,18 +86,29 @@ class Loader:
             assert self.unsafe, self._unsafe_msg(self.unsafe, file, ext)
             import numpy as np
             return np.load(file, **self.kwargs, allow_pickle=self.unsafe)
-        elif ext in ['.gz', '.json.gz', '.pkl.gz', '.npy.gz']:
-            with gzip.GzipFile(file, 'rb') as f:
-                if str(file).endswith('.json.gz'):
+        elif ext in ['.gz', '.json.gz', '.pkl.gz', '.npy.gz', '.wav.gz']:
+            if ext == '.gz':
+                ext = ''.join(file.suffixes[-2:])
+
+            if isinstance(file, io.IOBase):
+                gzip_file = dict(fileobj=file)
+            else:
+                gzip_file = dict(filename=file)
+
+            with gzip.GzipFile(**gzip_file, mode='rb') as f:
+                if ext == '.json.gz':
                     return json.loads(f.read().decode())
-                elif str(file).endswith('.pkl.gz'):
+                elif ext == '.pkl.gz':
                     assert self.unsafe, self._unsafe_msg(self.unsafe, file, ext)
                     return pickle.load(f)
-                elif str(file).endswith('.npy.gz'):
+                elif ext == '.npy.gz':
                     assert self.unsafe, (self.unsafe, file)
                     return np.load(f, allow_pickle=self.unsafe)
+                elif ext == '.wav.gz':
+                    from paderbox.io import load_audio
+                    return load_audio(f, **self.kwargs)
                 else:
-                    raise ValueError(file)
+                    raise ValueError(ext, file)
         elif ext in ['.wv1', '.wv2']:
             from paderbox.io.audioread import read_nist_wsj
             date, sampling_rate = read_nist_wsj(file)
@@ -106,7 +117,7 @@ class Loader:
             assert self.unsafe, self._unsafe_msg(self.unsafe, file, ext)
             import torch
             return torch.load(str(file), map_location='cpu')
-        elif str(file).endswith('.mat'):
+        elif ext in ['.mat']:
             # ToDo: Is hdf5 safe or unsafe?  (loadmat uses hdf5)
             import scipy.io as sio
             return sio.loadmat(file)
@@ -114,7 +125,7 @@ class Loader:
             if self.ignore_type_error and '.' not in str(file):
                 return str(file)
             else:
-                raise ValueError(file)
+                raise ValueError(file, ext)
 
     def _unsafe_msg(self, unsafe, file, ext):
         return (
@@ -254,7 +265,7 @@ def load(
       execute arbitrary code during unpickling. Never unpickle
       data that could have come from an untrusted source, or that
       could have been tampered with.
-    
+
     """
     loader = Loader(
         ignore_type_error=ignore_type_error,

--- a/paderbox/utils/profiling.py
+++ b/paderbox/utils/profiling.py
@@ -3,8 +3,6 @@ import line_profiler
 import memory_profiler
 import cProfile
 import time as time
-from pycallgraph import PyCallGraph
-from pycallgraph.output import GraphvizOutput
 from inspect import isclass, isfunction
 from functools import wraps
 
@@ -63,6 +61,8 @@ def gprun(func):
     :param func:
     :return:
     """
+    from pycallgraph import PyCallGraph
+    from pycallgraph.output import GraphvizOutput
     def profiled_func(*args, **kwargs):
         with PyCallGraph(output=GraphvizOutput()):
             return func(*args, **kwargs)


### PR DESCRIPTION
 - load: Add support for .wav.gz and file descriptor
 - dump: support flac, flac.gz and wav.gz
 - lazy import pycallgraph
 - Fix to_rttm_str: remove "same speaker" overlap
 - cache_loader.check: Add keepfree_gigabytes option