### PR TITLE
Replace deprecated pprint_val in context_manager.py

### DIFF
--- a/paderbox/visualization/context_manager.py
+++ b/paderbox/visualization/context_manager.py
@@ -61,7 +61,7 @@ class DollarFormatter(ScalarFormatter):
                 if self.formatting is not None and x % 1:
                     s = self.formatting.format(x)
                 else:
-                    s = self.pprint_val(x)
+                    s = self.format_data_short(x)
                 return rf'\${self.fix_minus(s)}\$'
             else:
                 return x


### PR DESCRIPTION
In order to fix an error in the LaTeX-Export notebook, i got the error that the method pprint_val was not found. It seems to be no longer present in ScalarFormatter class of newer matplotlib versions and could possibly be replaced with format_data_short to achieve the result.