### PR TITLE
DiskCacheLoader: Allow a cache reuse and use atomic file operations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,6 @@ jobs:
     - name: Test with pytest
       run: |
         pytest -v
-        python -m coverage xml --include="paderbox*"
     - name: Codecov
       run: |
         codecov

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -38,5 +38,3 @@ jobs:
     - name: Test with pytest
       run: pytest -v
 
-    - name: coverage
-      run: python -m coverage xml --include="paderbox*"

--- a/paderbox/io/atomic.py
+++ b/paderbox/io/atomic.py
@@ -126,7 +126,7 @@ def open_atomic(file, mode, *args, force=False, **kwargs):
 
     assert 'w' in mode, mode
 
-    if os.name == 'nt':
+    if os.name == 'nt':  # Windows
         tmp_f = tempfile.NamedTemporaryFile(
                     mode, *args, **kwargs, delete=False, prefix=file, dir=os.getcwd()
             )
@@ -163,7 +163,7 @@ def open_atomic(file, mode, *args, force=False, **kwargs):
             # close file
             if not skip_close:
                 close_and_remove()
-    else:
+    else:  # Linux, ...
         with tempfile.NamedTemporaryFile(
             mode, *args, **kwargs, prefix=file, dir=os.getcwd()
         ) as tmp_f:

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ test = [
     'wavefile',  # for reading .flac audio
     'dill',
     'pathos',
+    'nbformat',  # Used in paderbox/utils/strip_solution.py
     # 'pyzmq',
     # 'pymatbridge',  # need pyzmq to be installed manually
     'tqdm',


### PR DESCRIPTION
 - Allow a reuse
 - Atomic file operations (avoid raise conditions across processes)
 - Option to disable caching, i.e. change a flag instead of rewrite the code
 - Fallback to no caching, when not enough space left.
 - Add recursive load