### PR TITLE
Allow slicing notation in audio file names

### DIFF
--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -78,6 +78,9 @@ def load_audio(
     stop : int, optional
         The index after the last frame to be read.  A negative value
         counts from the end.  Not allowed if `frames` is given.
+    channel : int or slice or list of int or tuple of int
+        Channel(s) to select from a multichannel audio file. Can be anything
+        that can index a numpy array along a single dimension.
     dtype : {'float64', 'float32', 'int32', 'int16'}, optional
         Data type of the returned array, by default ``'float64'``.
         Floating point audio data is typically in the range from
@@ -89,39 +92,28 @@ def load_audio(
             scale the data to [-1.0, 1.0). If the file contains
             ``np.array([42.6], dtype='float32')``, you will read
             ``np.array([43], dtype='int32')`` for ``dtype='int32'``.
+    unit: 'samples' or 'seconds'
+        The unit of `start`, `stop` and `frames` values
+    expected_sample_rate: int, optional
+        The expected sample rate of the loaded audio file. This function raises
+        a ValueError when the sample rate of the file differs from
+        `expected_sample_rate`
+    fill_value : float, optional
+        If more frames are requested than available in the file, the
+        rest of the output is being filled with `fill_value`.  If
+        `fill_value` is not specified, a smaller array is returned.
+    return_sample_rate: bool
+        Whether to return the sample rate as a second element
 
     Returns
     -------
-    audiodata : numpy.ndarray or type(out)
+    audiodata : numpy.ndarray
         A two-dimensional (frames x channels) NumPy array is returned.
         If the sound file has only one channel, a one-dimensional array
-        is returned.  Use ``always_2d=True`` to return a two-dimensional
-        array anyway.
-
-        If `out` was specified, it is returned.  If `out` has more
-        frames than available in the file (or if `frames` is smaller
-        than the length of `out`) and no `fill_value` is given, then
-        only a part of `out` is overwritten and a view containing all
-        valid frames is returned.
-
-    Other Parameters
-    ----------------
-    always_2d : bool, optional
-        By default, reading a mono sound file will return a
-        one-dimensional array.  With ``always_2d=True``, audio data is
-        always returned as a two-dimensional array, even if the audio
-        file has only one channel.
-    fill_value : float, optional
-        If more frames are requested than available in the file, the
-        rest of the output is be filled with `fill_value`.  If
-        `fill_value` is not specified, a smaller array is returned.
-    out : numpy.ndarray or subclass, optional
-        If `out` is specified, the data is written into the given array
-        instead of creating a new array.  In this case, the arguments
-        `dtype` and `always_2d` are silently ignored!  If `frames` is
-        not given, it is obtained from the length of `out`.
-    samplerate, channels, format, subtype, endian, closefd
-        See :class:`SoundFile`.
+        is returned.
+    audiodata, sample_rate : (numpy.ndarray, int)
+        Additionally the sample reate is returned when `return_sample_rate`
+        is set to `True`.
 
     Examples
     --------
@@ -276,7 +268,8 @@ def load_audio(
 
     # Slice along channel dimension if channel_slice is given
     if channel is not None:
-        signal = signal[channel,]
+        assert signal.ndim == 2 or channel == 0, (signal.shape, channel)
+        signal = signal[channel, ]
         if signal.size == 0:
             raise ValueError('Returned signal would be empty')
 

--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -233,7 +233,10 @@ def load_audio(
                     dtype = mapping[f.subtype]
 
                 frames = f._prepare_read(start=start, stop=stop, frames=frames)
-                data = f.read(frames=frames, dtype=dtype, fill_value=fill_value)
+                data = f.read(
+                    frames=frames, dtype=dtype, fill_value=fill_value,
+                    always_2d=channel is not None
+                )
             signal, sample_rate = data, f.samplerate
     except RuntimeError as e:
         if isinstance(path, (Path, str)):
@@ -268,7 +271,7 @@ def load_audio(
 
     # Slice along channel dimension if channel_slice is given
     if channel is not None:
-        assert signal.ndim == 2 or channel == 0, (signal.shape, channel)
+        assert signal.ndim == 2, (signal.shape, channel)
         signal = signal[channel, ]
         if signal.size == 0:
             raise ValueError('Returned signal would be empty')
@@ -281,6 +284,7 @@ def load_audio(
 
 # https://jex.im/regulex/#!flags=&re=%5C%5B(%5Cd%2B)%3F%3A(%5Cd%2B)%3F(%3F%3A%2C(%3F%3A(%5Cd%2B)%3F%3A(%5Cd%2B)%3F%7C(%5Cd%2B)%3F))%3F%5C%5D
 _PATTERN = r'\[(\d+)?:(\d+)?(?:,(?:(\d+)?:(\d+)?|(\d+)?))?\]'
+
 
 def _parse_audio_slice(
         path,

--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -179,7 +179,7 @@ def load_audio(
     path = normalize_path(path, as_str=True)
 
     # Set start and stop when encoded in the filename
-    if '::' in path:
+    if isinstance(path, str) and '::' in path:
         assert unit == 'samples', unit
         assert frames == -1, frames
         path, start, stop, channel = _parse_audio_slice(

--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -334,7 +334,7 @@ def _parse_audio_slice(
     except Exception as e:
         raise ValueError(path) from e
 
-    if channel is None:
+    if channel is None and not (channel_start is None and channel_stop is None):
         channel = slice(channel_start, channel_stop)
 
     if start is None:

--- a/paderbox/io/audioread.py
+++ b/paderbox/io/audioread.py
@@ -126,7 +126,7 @@ def load_audio(
     >>> data = load_audio(path)
     >>> data.shape
     (49600,)
-    >>> data = load_audio(str(path) + '::[8000:16000]')
+    >>> data = load_audio(Path(str(path) + '::[8000:16000]'))
     >>> data.shape
     (8000,)
 

--- a/paderbox/io/wrapper_load.py
+++ b/paderbox/io/wrapper_load.py
@@ -48,6 +48,10 @@ class Loader:
                     f'{type(file)} is not supported without the argument "ext.\n"'
                     f'e.g. load(..., ext=".json")'
                 )
+            # load_audio uses ".../file.wav::[slice]" notation to load a part 
+            # of an audio file. We have to remove the slice form the extension 
+            # for a correct dispatch
+            ext = ext.split('::')[0]
         else:
             ext = self.ext
 


### PR DESCRIPTION
Add notation to select channels and a slice from the audio path passed to `load_audio`