### PR TITLE
Fix window function imports from scipy.signal

### DIFF
--- a/paderbox/transform/module_mfcc.py
+++ b/paderbox/transform/module_mfcc.py
@@ -171,8 +171,8 @@ def modmfcc(
         number_of_filters=40, stft_size=512,
         lowest_frequency=0, highest_frequency=None,
         preemphasis_factor=0.97, ceplifter=22,
-        stft_window=scipy.signal.hamming,
-        mod_length=16, mod_shift=8, mod_window=scipy.signal.hamming,
+        stft_window=scipy.signal.windows.hamming,
+        mod_length=16, mod_shift=8, mod_window=scipy.signal.windows.hamming,
         avg_length=1, avg_shift=1
 ):
     """

--- a/paderbox/transform/module_mfcc.py
+++ b/paderbox/transform/module_mfcc.py
@@ -11,7 +11,7 @@ def mfcc(time_signal, sample_rate=16000,
          number_of_filters=26, stft_size=512,
          lowest_frequency=0, highest_frequency=None,
          preemphasis_factor=0.97, ceplifter=22,
-         window=scipy.signal.hamming):
+         window=scipy.signal.windows.hamming):
     """
     Compute MFCC features from an audio signal.
 

--- a/tests/transform_tests/test_stft.py
+++ b/tests/transform_tests/test_stft.py
@@ -24,7 +24,7 @@ import numpy
 
 
 def stft_single_channel(time_signal, size=1024, shift=256,
-                        window=signal.blackman,
+                        window=signal.windows.blackman,
                         fading=True, window_length=None):
     """
     Calculates the short time Fourier transformation of a single channel time
@@ -213,7 +213,7 @@ class TestSTFTMethods(unittest.TestCase):
         tc.assert_equal(X.shape, (3, 257))
 
     def test_compare_both_biorthogonal_window_variants(self):
-        window = signal.blackman(1024)
+        window = signal.windows.blackman(1024)
         shift = 256
 
         for_result = _biorthogonal_window_loopy(window, shift)
@@ -236,7 +236,7 @@ class TestSTFTMethods(unittest.TestCase):
                 res += roll_zeropad(analysis_window, shift * i)
             return res
 
-        window = signal.blackman(1024)
+        window = signal.windows.blackman(1024)
         shift = 256
 
         synthesis_window = _biorthogonal_window_brute_force(window, shift)
@@ -256,7 +256,7 @@ class TestSTFTMethods(unittest.TestCase):
                 res += roll_zeropad(analysis_window, shift * i)
             return res
 
-        window = signal.blackman(400)
+        window = signal.windows.blackman(400)
         shift = 160
 
         synthesis_window = _biorthogonal_window_brute_force(window, shift)
@@ -268,7 +268,7 @@ class TestSTFTMethods(unittest.TestCase):
         from paderbox.utils.timer import TimerDict
         timer = TimerDict()
 
-        window = signal.blackman(1024)
+        window = signal.windows.blackman(1024)
         shift = 256
 
         with timer['loopy']:


### PR DESCRIPTION
In version 1.13.0, scipy removed the ability to import window functions from the signal namespace (see https://github.com/scipy/scipy/pull/19676). Window functions such as `hamming` have now to be imported from `scipy.signal.windows`.

scipy 1.13.0 release notes: https://scipy.github.io/devdocs/release/1.13.0-notes.html#pull-requests-for-1-13-0