### PR TITLE
fixed deprecated bug python 3.11 - np.int to int

### DIFF
--- a/paderbox/visualization/plot.py
+++ b/paderbox/visualization/plot.py
@@ -1078,7 +1078,7 @@ def activity(
         max(i[1] for i in d_.normalized_intervals)
         for d_ in activity_intervals
     ))
-    num_active = np.zeros((length,), dtype=np.int)
+    num_active = np.zeros((length,), dtype=int)
     for a in activity_intervals:
         num_active += a[:length]
 


### PR DESCRIPTION
Proposal to fix deprecated code to run on python 3.11