### PR TITLE
Add support for pytorch 2.6 in pb.io.load for pth files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,10 +9,15 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false  # Let other jobs keep running even if one fails
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ ubuntu-latest ]
+        include:
+          - os: ubuntu-22.04
+            python-version: 3.7
 
     steps:
     - uses: actions/checkout@v2

--- a/jenkins_common.bash
+++ b/jenkins_common.bash
@@ -10,7 +10,7 @@ trap 'echo -e "${green}$ $BASH_COMMAND ${NC}"' DEBUG
 # Force Exit 0
 trap 'exit 0' EXIT SIGINT SIGTERM
 
-PYTHON_PATH=/net/software/python/2022_02/anaconda
+PYTHON_PATH=/net/software/python/2024_06/anaconda
 
 source $PYTHON_PATH/bin/activate
 
@@ -26,6 +26,9 @@ ls $PYTHON_PATH/lib/python3.9/lib-dynload/../../ > /dev/null
 
 # Some debug information
 env
+
+# list of all installed Python packages and their versions
+pip list
 
 # adds a KALDI_ROOT
 source "${TOOLBOX}/bash/kaldi.bash"

--- a/paderbox/array/interval/rttm.py
+++ b/paderbox/array/interval/rttm.py
@@ -141,8 +141,8 @@ def to_rttm_str(data, sample_rate=16000):
     >>> ar2 = np.zeros(shape=50000, dtype=bool)
     >>> ar2[0:32000] = 1
     >>> data = {'S02': {'1': ar1, '2': ar2}}
-    >>> data
-    {'S02': {'1': ArrayInterval("0:16000, 32000:48000", shape=None), '2': array([ True,  True,  True, ..., False, False, False])}}
+    >>> data  # numpy 2.2 adds a shape argument to the repr  # doctest: +ELLIPSIS
+    {'S02': {'1': ArrayInterval("0:16000, 32000:48000", shape=None), '2': array([ True,  True,  True, ..., False, False, False]...)}}
     >>> print(to_rttm_str(data))
     SPEAKER S02 1 0 1 <NA> <NA> 1 <NA>
     SPEAKER S02 1 2 1 <NA> <NA> 1 <NA>

--- a/paderbox/io/wrapper_load.py
+++ b/paderbox/io/wrapper_load.py
@@ -150,6 +150,10 @@ class Loader:
         ...         print("Failed as it should. The message and type changes between torch versions.")
         Failed as it should. The message and type changes between torch versions.
 
+            
+        >>> if  version.parse(torch.__version__) < version.parse('2.6'):
+        ...     pytest.skip("Proper weights_only is only supported in torch >= 2.6")
+
         >>> with tempfile.NamedTemporaryFile(suffix='.pth') as tmp:
         ...     torch.save({'a': np.array([1])}, tmp.name)
         ...     loader(tmp.name)

--- a/paderbox/io/wrapper_load.py
+++ b/paderbox/io/wrapper_load.py
@@ -1,3 +1,4 @@
+import os
 import io
 import gzip
 import json

--- a/paderbox/io/wrapper_load.py
+++ b/paderbox/io/wrapper_load.py
@@ -154,6 +154,7 @@ class Loader:
 
             
         >>> if  version.parse(torch.__version__) < version.parse('2.6'):
+        ...     import pytest
         ...     pytest.skip("Proper weights_only is only supported in torch >= 2.6")
 
         >>> with tempfile.NamedTemporaryFile(suffix='.pth') as tmp:

--- a/paderbox/io/wrapper_load.py
+++ b/paderbox/io/wrapper_load.py
@@ -132,6 +132,7 @@ class Loader:
 
     def pth(self, file, map_location='cpu', **kwargs):
         """
+        >>> from packaging import version
         >>> import tempfile
         >>> import torch
         >>> import numpy as np

--- a/paderbox/io/wrapper_load.py
+++ b/paderbox/io/wrapper_load.py
@@ -138,16 +138,18 @@ class Loader:
         >>> import torch
         >>> import numpy as np
         >>> loader = Loader(False, None, unsafe=True)
-        >>> with tempfile.NamedTemporaryFile(suffix='.pth') as tmp:
-        ...     torch.save({'a': os.system}, tmp.name)
-        ...     loader(tmp.name)
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     file = Path(tmpdir) / 'test.pth'
+        ...     torch.save({'a': os.system}, file)
+        ...     loader(file)
         {'a': <built-in function system>}
 
         >>> loader = Loader(False, None, unsafe=False)
-        >>> with tempfile.NamedTemporaryFile(suffix='.pth') as tmp:
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     file = Path(tmpdir) / 'test.pth'
         ...     try:
-        ...         torch.save({'a': os.system}, tmp.name)
-        ...         loader(tmp.name)
+        ...         torch.save({'a': os.system}, file)
+        ...         loader(file)
         ...     except Exception as e:
         ...         print("Failed as it should. The message and type changes between torch versions.")
         Failed as it should. The message and type changes between torch versions.
@@ -157,9 +159,10 @@ class Loader:
         ...     import pytest
         ...     pytest.skip("Proper weights_only is only supported in torch >= 2.6")
 
-        >>> with tempfile.NamedTemporaryFile(suffix='.pth') as tmp:
-        ...     torch.save({'a': np.array([1])}, tmp.name)
-        ...     loader(tmp.name)
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     file = Path(tmpdir) / 'test.pth'
+        ...     torch.save({'a': np.array([1])}, file)
+        ...     loader(file)
         {'a': array([1])}
         """
         kwargs['map_location'] = map_location

--- a/paderbox/io/wrapper_load.py
+++ b/paderbox/io/wrapper_load.py
@@ -162,7 +162,7 @@ class Loader:
 
         weights_only = kwargs.pop('weights_only', not self.unsafe)
         
-        if version.parse(torch.__version__) < version.parse('2.4'):
+        if version.parse(torch.__version__) < version.parse('2.6'):
             assert not weights_only, self._unsafe_msg(f'{self.unsafe} (weights_only={weights_only})', file, '.pth')
             return torch.load(str(file), **kwargs)
         elif not weights_only:
@@ -178,6 +178,7 @@ class Loader:
                 # loaded with torch.load(weights_only=True). Starting from 2.6
                 # weights_only=True becomes a default and requires allowlisting of objects
                 # being loaded.
+                # CB: torch.serialization.safe_globals was introduced in 2.5 or 2.6.
                 # See: https://github.com/pytorch/pytorch/pull/137602
                 # See: https://pytorch.org/docs/stable/notes/serialization.html#torch.serialization.add_safe_globals
                 # See: https://github.com/huggingface/accelerate/pull/3036

--- a/paderbox/io/wrapper_load.py
+++ b/paderbox/io/wrapper_load.py
@@ -4,6 +4,7 @@ import json
 import pickle
 import functools
 from pathlib import Path
+import contextlib
 
 from paderbox.io.path_utils import normalize_path
 
@@ -66,7 +67,7 @@ class Loader:
             # ToDo: Is hdf5 safe or unsafe?
             from paderbox.io.hdf5 import load_hdf5
             return load_hdf5(file)
-        elif ext in ['.yaml']:
+        elif ext in ['.yaml', '.yml']:
             with file.open('r') as fp:
                 import yaml
                 if self.unsafe:
@@ -118,9 +119,7 @@ class Loader:
             date, sampling_rate = read_nist_wsj(file)
             return date
         elif ext in ['.pth']:
-            assert self.unsafe, self._unsafe_msg(self.unsafe, file, ext)
-            import torch
-            return torch.load(str(file), map_location='cpu')
+            return self.pth(file, map_location='cpu', weights_only=not self.unsafe)
         elif ext in ['.mat']:
             # ToDo: Is hdf5 safe or unsafe?  (loadmat uses hdf5)
             import scipy.io as sio
@@ -130,6 +129,79 @@ class Loader:
                 return str(file)
             else:
                 raise ValueError(file, ext)
+
+    def pth(self, file, map_location='cpu', **kwargs):
+        """
+        >>> import tempfile
+        >>> import torch
+        >>> import numpy as np
+        >>> loader = Loader(False, None, unsafe=True)
+        >>> with tempfile.NamedTemporaryFile(suffix='.pth') as tmp:
+        ...     torch.save({'a': os.system}, tmp.name)
+        ...     loader(tmp.name)
+        {'a': <built-in function system>}
+
+        >>> loader = Loader(False, None, unsafe=False)
+        >>> with tempfile.NamedTemporaryFile(suffix='.pth') as tmp:
+        ...     try:
+        ...         torch.save({'a': os.system}, tmp.name)
+        ...         loader(tmp.name)
+        ...     except Exception as e:
+        ...         print("Failed as it should. The message and type changes between torch versions.")
+        Failed as it should. The message and type changes between torch versions.
+
+        >>> with tempfile.NamedTemporaryFile(suffix='.pth') as tmp:
+        ...     torch.save({'a': np.array([1])}, tmp.name)
+        ...     loader(tmp.name)
+        {'a': array([1])}
+        """
+        kwargs['map_location'] = map_location
+
+        from packaging import version  # distutils is deprecated
+        import torch
+
+        weights_only = kwargs.pop('weights_only', not self.unsafe)
+        
+        if version.parse(torch.__version__) < version.parse('2.4'):
+            assert not weights_only, self._unsafe_msg(f'{self.unsafe} (weights_only={weights_only})', file, '.pth')
+            return torch.load(str(file), **kwargs)
+        elif not weights_only:
+            return torch.load(str(file), weights_only=False, **kwargs)
+        else:
+            import numpy as np
+
+            # Original code for _safe_globals:
+            #  - https://github.com/huggingface/transformers/pull/34632
+            #  - https://github.com/fgnt/padertorch/pull/163
+            def _safe_globals():
+                # Starting from version 2.4 PyTorch introduces a check for the objects
+                # loaded with torch.load(weights_only=True). Starting from 2.6
+                # weights_only=True becomes a default and requires allowlisting of objects
+                # being loaded.
+                # See: https://github.com/pytorch/pytorch/pull/137602
+                # See: https://pytorch.org/docs/stable/notes/serialization.html#torch.serialization.add_safe_globals
+                # See: https://github.com/huggingface/accelerate/pull/3036
+
+                np_core = (
+                    np._core if version.parse(np.__version__)
+                    >= version.parse("2.0.0") else np.core
+                )
+                allowlist = [
+                    np_core.multiarray._reconstruct,  # added in transformers/pull/34632
+                    np_core.multiarray.scalar,  # added in padertorch/pull/163
+                    np.ndarray,  # added in transformers/pull/34632
+                    np.dtype,  # added in transformers/pull/34632
+                    # numpy >1.25 defines numpy.dtypes.UInt32DType, but type works for all versions of numpy
+                    type(np.dtype(np.int64)),  # added in initial paderbox commit
+                    type(np.dtype(np.uint32)),  # added in transformers/pull/34632
+                    type(np.dtype(np.float64)),  # added in padertorch/pull/163
+                    type(np.dtype(np.float32)),  # added in initial paderbox commit
+                ]
+                
+                return torch.serialization.safe_globals(allowlist)
+            
+            with _safe_globals():
+                return torch.load(str(file), weights_only=True, **kwargs)
 
     def _unsafe_msg(self, unsafe, file, ext):
         return (


### PR DESCRIPTION
PyTorch 2.6 changed `weights_only` from `False` to `True` and forgot to support `numpy`.

- apply https://github.com/fgnt/padertorch/pull/163 to `pb.io.load`
 - pth supports now unsafe=False via `torch.load(..., weights_only=True)`
 - Note: For `unsafe=False` to be safe needs at least torch 2.6. Earlier versions have bugs, see e.g. https://github.com/pytorch/pytorch/issues/152006
 - support .yml as alternative to .yaml